### PR TITLE
Add detailed README with operator engine description, table, and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-# blackroad-os-operator
-Operator engine for BlackRoad OS — runs jobs, schedulers, background workers, and coordinates agent workflows across OS, Prism, and Lucidia. Handles automation, task orchestration, and system-level operations.
+# BlackRoad OS — Operator Engine  
+  
+## Short Description  
+  
+Background workers, schedulers, and AI agent orchestration engine.  
+  
+## Long Description  
+  
+Operator Engine is the automation heart of BlackRoad OS — running jobs, queues, schedulers, system-level background processes, and multi-agent workflows. It integrates with Lucidia, coordinates actions across Core and API, and ensures deterministic task execution.  
+  
+## Structured Table  
+  
+| Field          | Value                                      |  
+| -------------- | ------------------------------------------ |  
+| **Purpose**    | Background jobs, schedulers, orchestration |  
+| **Depends On** | API Gateway                                |  
+| **Used By**    | Core, Prism, Lucidia Agents                |  
+| **Owner**      | Cece (Operator group)                      |  
+| **Status**     | High-priority active                       |  
+  
+## Roadmap Board (Operator)  
+  
+Columns:  
+  
+* **Task Pipeline Drafting**  
+* **Worker Architecture**  
+* **Queueing**  
+* **Agent Hooks**  
+* **Load Tests**  
+* **Productionization**  
+  
+Sample tasks:  
+  
+* Worker heartbeat  
+* Retry logic  
+* Scheduler runtime  
+* System task registry  
+* Async orchestration framework 


### PR DESCRIPTION
Expanded the README to provide a structured overview of the BlackRoad OS Operator Engine, including short and long descriptions, a structured table, and a roadmap.