### PR TITLE
Add operator worker queue and deployment plumbing

### DIFF
--- a/.github/workflows/operator-deploy.yaml
+++ b/.github/workflows/operator-deploy.yaml
@@ -1,0 +1,52 @@
+name: Deploy Operator to Railway
+
+on:
+  push:
+    branches:
+      - dev
+      - staging
+      - main
+
+jobs:
+  deploy-operator:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - branch: dev
+            environment: dev
+            health_url: https://dev.operator.blackroad.systems/health
+          - branch: staging
+            environment: staging
+            health_url: https://staging.operator.blackroad.systems/health
+          - branch: main
+            environment: prod
+            health_url: https://operator.blackroad.systems/health
+    if: github.ref_name == matrix.branch
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy operator service
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          railway up --service operator --environment ${{ matrix.environment }} --ci
+
+      - name: Health check operator
+        run: |
+          curl -f ${{ matrix.health_url }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,14 @@
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "ioredis": "^5.4.1",
+        "node-fetch": "^2.7.0",
         "pg": "^8.11.5"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
         "@types/ioredis": "^4.28.10",
         "@types/node": "^20.11.30",
+        "@types/node-fetch": "^2.6.4",
         "@types/pg": "^8.10.9",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.5"
@@ -179,6 +181,17 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
     "node_modules/@types/pg": {
       "version": "8.15.6",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
@@ -290,6 +303,13 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -376,6 +396,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -434,6 +467,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -540,6 +583,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -654,6 +713,23 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -735,6 +811,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -922,6 +1014,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-inspect": {
@@ -1364,6 +1476,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -1474,6 +1592,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "ioredis": "^5.4.1",
+    "node-fetch": "^2.7.0",
     "pg": "^8.11.5"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/ioredis": "^4.28.10",
+    "@types/node-fetch": "^2.6.4",
     "@types/node": "^20.11.30",
     "@types/pg": "^8.10.9",
     "ts-node": "^10.9.2",

--- a/railway.json
+++ b/railway.json
@@ -1,31 +1,9 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
-  "project": "blackroad-agents",
+  "project": "blackroad-os-operator",
   "services": [
     {
-      "name": "agents-api",
-      "source": ".",
-      "build": {
-        "command": "npm install && npm run build"
-      },
-      "start": {
-        "command": "npm run start:api"
-      },
-      "envVars": [
-        "NODE_ENV",
-        "PORT",
-        "DATABASE_URL",
-        "REDIS_URL",
-        "CORE_API_URL",
-        "PUBLIC_AGENTS_URL",
-        "LOG_LEVEL",
-        "APP_VERSION",
-        "GIT_COMMIT",
-        "BUILD_TIME"
-      ]
-    },
-    {
-      "name": "agents-worker",
+      "name": "operator",
       "source": ".",
       "build": {
         "command": "npm install && npm run build"
@@ -33,16 +11,22 @@
       "start": {
         "command": "npm run start:worker"
       },
+      "healthcheck": {
+        "path": "/health"
+      },
       "envVars": [
         "NODE_ENV",
-        "DATABASE_URL",
-        "REDIS_URL",
+        "OPERATOR_PORT",
         "CORE_API_URL",
-        "PUBLIC_AGENTS_URL",
+        "AGENTS_API_URL",
+        "QUEUE_POLL_INTERVAL_MS",
+        "JOB_MAX_ATTEMPTS",
         "LOG_LEVEL",
         "APP_VERSION",
         "GIT_COMMIT",
-        "BUILD_TIME"
+        "BUILD_TIME",
+        "DATABASE_URL",
+        "REDIS_URL"
       ]
     }
   ]

--- a/src/api/routes/health.ts
+++ b/src/api/routes/health.ts
@@ -9,7 +9,8 @@ router.get('/health', async (_req, res) => {
   const [db, redis] = await Promise.all([checkDbConnection(), checkRedisConnection()]);
 
   res.json({
-    status: db === 'ok' && (redis === 'ok' || redis === 'disabled') ? 'ok' : 'error',
+    status:
+      (db === 'ok' || db === 'disabled') && (redis === 'ok' || redis === 'disabled') ? 'ok' : 'error',
     timestamp: new Date().toISOString(),
     environment: config.env,
     checks: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,20 @@ dotenv.config();
 const pkgPath = path.join(__dirname, '..', 'package.json');
 const pkgJson = fs.existsSync(pkgPath) ? JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) : { version: '0.0.0' };
 
-type RequiredEnv = 'NODE_ENV' | 'DATABASE_URL' | 'CORE_API_URL' | 'PUBLIC_AGENTS_URL';
+type RequiredEnv = 'CORE_API_URL' | 'AGENTS_API_URL';
+
+type OptionalEnv =
+  | 'NODE_ENV'
+  | 'OPERATOR_PORT'
+  | 'PORT'
+  | 'QUEUE_POLL_INTERVAL_MS'
+  | 'JOB_MAX_ATTEMPTS'
+  | 'LOG_LEVEL'
+  | 'APP_VERSION'
+  | 'GIT_COMMIT'
+  | 'BUILD_TIME'
+  | 'DATABASE_URL'
+  | 'REDIS_URL';
 
 function getEnv(name: RequiredEnv, fallback?: string): string {
   const value = process.env[name] ?? fallback;
@@ -17,34 +30,49 @@ function getEnv(name: RequiredEnv, fallback?: string): string {
   return value;
 }
 
-function getOptionalEnv(name: string, fallback?: string): string | undefined {
+function getOptionalEnv(name: OptionalEnv, fallback?: string): string | undefined {
   return process.env[name] ?? fallback;
+}
+
+function getNumberEnv(name: OptionalEnv, fallback: number): number {
+  const raw = getOptionalEnv(name);
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`Invalid number for environment variable ${name}: ${raw}`);
+  }
+  return parsed;
 }
 
 export interface RuntimeConfig {
   env: string;
-  port: number;
-  dbUrl: string;
-  redisUrl?: string;
+  operatorPort: number;
   coreApiUrl: string;
-  publicAgentsUrl: string;
+  agentsApiUrl: string;
+  queuePollIntervalMs: number;
+  jobMaxAttempts: number;
   logLevel: string;
   appVersion: string;
   gitCommit?: string;
   buildTime?: string;
+  databaseUrl?: string;
+  redisUrl?: string;
 }
 
 export const config: RuntimeConfig = {
-  env: getEnv('NODE_ENV', 'development'),
-  port: Number(process.env.PORT ?? 3000),
-  dbUrl: getEnv('DATABASE_URL'),
+  env: getOptionalEnv('NODE_ENV', 'development') as string,
+  operatorPort: getNumberEnv('OPERATOR_PORT', Number(getOptionalEnv('PORT', '3001'))),
+  coreApiUrl: getEnv('CORE_API_URL', 'http://localhost:4000'),
+  agentsApiUrl: getEnv('AGENTS_API_URL', 'http://localhost:4100'),
+  queuePollIntervalMs: getNumberEnv('QUEUE_POLL_INTERVAL_MS', 1_000),
+  jobMaxAttempts: getNumberEnv('JOB_MAX_ATTEMPTS', 3),
+  logLevel: getOptionalEnv('LOG_LEVEL', 'info') as string,
+  appVersion: getOptionalEnv('APP_VERSION', pkgJson.version) as string,
+  gitCommit: getOptionalEnv('GIT_COMMIT') ?? process.env.RAILWAY_GIT_COMMIT_SHA,
+  buildTime: getOptionalEnv('BUILD_TIME'),
+  databaseUrl: getOptionalEnv('DATABASE_URL'),
   redisUrl: getOptionalEnv('REDIS_URL'),
-  coreApiUrl: getEnv('CORE_API_URL'),
-  publicAgentsUrl: getEnv('PUBLIC_AGENTS_URL'),
-  logLevel: getOptionalEnv('LOG_LEVEL') ?? 'info',
-  appVersion: process.env.APP_VERSION ?? pkgJson.version ?? '0.0.0',
-  gitCommit: process.env.GIT_COMMIT ?? process.env.RAILWAY_GIT_COMMIT_SHA,
-  buildTime: process.env.BUILD_TIME,
 };
 
 export const isRedisEnabled = Boolean(config.redisUrl);
+export const isDatabaseEnabled = Boolean(config.databaseUrl);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,18 +1,24 @@
 import { Pool } from 'pg';
-import { config } from '../config';
+import { config, isDatabaseEnabled } from '../config';
 import { logger } from './logger';
 
 let pool: Pool | null = null;
 
 export function getDbPool(): Pool {
+  if (!config.databaseUrl) {
+    throw new Error('DATABASE_URL is not configured');
+  }
+
   if (!pool) {
-    pool = new Pool({ connectionString: config.dbUrl });
+    pool = new Pool({ connectionString: config.databaseUrl });
     logger.info('Initialized Postgres pool', { dbUrl: 'DATABASE_URL' });
   }
   return pool;
 }
 
-export async function checkDbConnection(): Promise<'ok' | 'error'> {
+export async function checkDbConnection(): Promise<'ok' | 'error' | 'disabled'> {
+  if (!isDatabaseEnabled) return 'disabled';
+
   try {
     const client = await getDbPool().connect();
     await client.query('SELECT 1');

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -13,7 +13,7 @@ function formatMessage(level: LogLevel, message: string, meta?: Record<string, u
   const base = {
     level,
     timestamp: new Date().toISOString(),
-    service: 'agents-runtime',
+    service: 'operator',
     env: config.env,
     message,
     ...meta,

--- a/src/worker/job-runner.ts
+++ b/src/worker/job-runner.ts
@@ -1,0 +1,171 @@
+import { randomUUID } from 'crypto';
+import fetch from 'node-fetch';
+import { config } from '../config';
+import { logger } from '../lib/logger';
+
+export type JobType = 'health-check' | 'sync-metadata';
+
+export interface JobPayloadMap {
+  'health-check': { targetUrl: string };
+  'sync-metadata': Record<string, unknown>;
+}
+
+type JobStatus = 'queued' | 'running' | 'completed' | 'failed';
+
+export interface Job<T extends JobType = JobType> {
+  id: string;
+  type: T;
+  payload: JobPayloadMap[T];
+  status: JobStatus;
+  attempts: number;
+  maxAttempts: number;
+  enqueuedAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  result?: unknown;
+  error?: string;
+}
+
+interface JobQueueState {
+  pending: number;
+  running: Job | null;
+  recent: Job[];
+}
+
+const pendingQueue: Job[] = [];
+let runningJob: Job | null = null;
+const recentJobs: Job[] = [];
+let loopStarted = false;
+
+function normalizeUrl(targetUrl: string): string {
+  const sanitized = targetUrl.replace(/\/$/, '');
+  return `${sanitized}/health`;
+}
+
+async function executeHealthCheck(payload: JobPayloadMap['health-check']) {
+  const url = normalizeUrl(payload.targetUrl);
+  const started = Date.now();
+
+  try {
+    const response = await fetch(url, { method: 'GET' });
+    const durationMs = Date.now() - started;
+    const body = await response.text();
+
+    return {
+      target: url,
+      ok: response.ok,
+      status: response.status,
+      durationMs,
+      body,
+    };
+  } catch (err) {
+    const durationMs = Date.now() - started;
+    logger.warn('Health check failed', { target: url, error: (err as Error).message, durationMs });
+    throw err;
+  }
+}
+
+async function executeSyncMetadata(payload: JobPayloadMap['sync-metadata']) {
+  logger.info('sync-metadata job triggered', { payload });
+  return { status: 'noop', payload };
+}
+
+async function executeJob(job: Job): Promise<unknown> {
+  switch (job.type) {
+    case 'health-check':
+      return executeHealthCheck(job.payload as JobPayloadMap['health-check']);
+    case 'sync-metadata':
+      return executeSyncMetadata(job.payload as JobPayloadMap['sync-metadata']);
+    default:
+      throw new Error(`Unsupported job type: ${job.type}`);
+  }
+}
+
+function validatePayload(type: JobType, payload: unknown): JobPayloadMap[JobType] {
+  if (type === 'health-check') {
+    if (!payload || typeof payload !== 'object' || typeof (payload as { targetUrl?: unknown }).targetUrl !== 'string') {
+      throw new Error('health-check job requires a payload.targetUrl string');
+    }
+    return { targetUrl: (payload as { targetUrl: string }).targetUrl } as JobPayloadMap[JobType];
+  }
+
+  if (type === 'sync-metadata') {
+    return (payload && typeof payload === 'object' ? payload : {}) as JobPayloadMap[JobType];
+  }
+
+  throw new Error(`Invalid job type: ${type}`);
+}
+
+function recordRecentJob(job: Job) {
+  recentJobs.unshift(job);
+  if (recentJobs.length > 20) {
+    recentJobs.pop();
+  }
+}
+
+async function processNextJob() {
+  if (runningJob || pendingQueue.length === 0) return;
+
+  const job = pendingQueue.shift() as Job;
+  runningJob = { ...job, status: 'running', startedAt: new Date().toISOString() };
+  logger.info('Processing job', { id: runningJob.id, type: runningJob.type, attempts: runningJob.attempts + 1 });
+
+  try {
+    runningJob.attempts += 1;
+    const result = await executeJob(runningJob);
+    runningJob.status = 'completed';
+    runningJob.result = result;
+    runningJob.completedAt = new Date().toISOString();
+    logger.info('Job completed', { id: runningJob.id, type: runningJob.type });
+  } catch (err) {
+    runningJob.error = (err as Error).message;
+    if (runningJob.attempts < runningJob.maxAttempts) {
+      runningJob.status = 'queued';
+      logger.warn('Job failed, re-queuing', { id: runningJob.id, attempts: runningJob.attempts, error: runningJob.error });
+      pendingQueue.push(runningJob);
+      runningJob = null;
+      return;
+    }
+    runningJob.status = 'failed';
+    runningJob.completedAt = new Date().toISOString();
+    logger.error('Job failed permanently', { id: runningJob.id, error: runningJob.error });
+  }
+
+  recordRecentJob(runningJob);
+  runningJob = null;
+}
+
+export function enqueueJob(type: JobType, payload: unknown): Job {
+  const validatedPayload = validatePayload(type, payload);
+
+  const job: Job = {
+    id: randomUUID(),
+    type,
+    payload: validatedPayload,
+    status: 'queued',
+    attempts: 0,
+    maxAttempts: config.jobMaxAttempts,
+    enqueuedAt: new Date().toISOString(),
+  };
+
+  pendingQueue.push(job);
+  logger.info('Enqueued job', { id: job.id, type: job.type });
+  return job;
+}
+
+export function getJobQueueState(): JobQueueState {
+  return {
+    pending: pendingQueue.length,
+    running: runningJob,
+    recent: [...recentJobs],
+  };
+}
+
+export function startJobLoop(): void {
+  if (loopStarted) return;
+  loopStarted = true;
+  logger.info('Starting in-memory job loop', { intervalMs: config.queuePollIntervalMs });
+  setInterval(() => {
+    void processNextJob();
+  }, config.queuePollIntervalMs);
+}


### PR DESCRIPTION
## Summary
- add centralized operator config and in-memory job runner for health-check and sync-metadata tasks
- expose worker HTTP endpoints for health, version, queue status, and job enqueueing
- add Railway service definition, deployment workflow, and updated README guidance

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f5e0291a48329af1bd624eca68dee)