### PR TITLE
Add in-memory job queue and enqueue endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,8 @@
     "dev": "tsx src/server.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/server.js",
-    "lint": "eslint ."
-    "dev": "ts-node-dev --respawn src/index.ts",
-    "dev:worker": "ts-node-dev --respawn src/worker/index.ts",
-    "build": "tsc",
-    "start": "node dist/index.js",
+    "lint": "eslint .",
+    "dev:worker": "tsx src/worker/index.ts",
     "start:worker": "node dist/worker/index.js"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,19 @@
 import express from 'express';
 import packageJson from '../package.json';
+import jobsRoutes from './routes/jobsRoutes';
 
 const app = express();
+
+app.use(express.json());
 
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok', service: 'operator' });
 });
-  app.get('/health', (_req, res) => {
-    res.json({ status: 'ok', service: 'operator' });
-  });
 
 app.get('/version', (_req, res) => {
   res.json({ version: packageJson.version, service: 'operator' });
 });
+
+app.use('/jobs', jobsRoutes);
 
 export default app;

--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -1,0 +1,15 @@
+import { Job } from './types';
+
+const queue: Job[] = [];
+
+export function enqueue(job: Job): void {
+  queue.push(job);
+}
+
+export function dequeue(): Job | undefined {
+  return queue.shift();
+}
+
+export function getQueueSize(): number {
+  return queue.length;
+}

--- a/src/jobs/types.ts
+++ b/src/jobs/types.ts
@@ -1,0 +1,6 @@
+export type Job = {
+  id: string;
+  type: string;
+  payload: Record<string, unknown>;
+  createdAt: string;
+};

--- a/src/routes/jobsRoutes.ts
+++ b/src/routes/jobsRoutes.ts
@@ -1,0 +1,34 @@
+import { Router } from 'express';
+import { enqueue, getQueueSize } from '../jobs/queue';
+import { Job } from '../jobs/types';
+
+const router = Router();
+
+router.post('/enqueue', (req, res) => {
+  const { type, payload } = req.body ?? {};
+
+  if (!type || typeof type !== 'string') {
+    res.status(400).json({ error: 'type is required and must be a string' });
+    return;
+  }
+
+  const jobPayload: Record<string, unknown> =
+    payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : {};
+
+  const job: Job = {
+    id: Date.now().toString(),
+    type,
+    payload: jobPayload,
+    createdAt: new Date().toISOString(),
+  };
+
+  enqueue(job);
+
+  res.status(201).json(job);
+});
+
+router.get('/status', (_req, res) => {
+  res.json({ service: 'operator', queueSize: getQueueSize() });
+});
+
+export default router;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,23 +1,22 @@
-import { InMemoryQueue } from './queue/in-memory-queue';
+import { dequeue, getQueueSize } from './jobs/queue';
 
 const HEARTBEAT_INTERVAL_MS = Number(process.env.WORKER_HEARTBEAT_MS ?? 10000);
-const queue = new InMemoryQueue<unknown>();
 
 function logHeartbeat(): void {
-  console.log(`[worker] heartbeat - queue size: ${queue.size()}`);
+  console.log(`[worker] heartbeat - queue size: ${getQueueSize()}`);
 }
 
 export function startWorker(): void {
   console.log('Starting worker loop');
 
   setInterval(() => {
-    const job = queue.dequeue();
+    const job = dequeue();
+
     if (job) {
-      console.log('[worker] processed job placeholder', job);
+      console.log(`[worker] processing job ${job.id} of type ${job.type}`);
+      return;
     }
 
     logHeartbeat();
   }, HEARTBEAT_INTERVAL_MS);
 }
-
-export { queue as operatorQueue };


### PR DESCRIPTION
## Summary
- add a Job type and in-memory queue helpers
- extend the worker loop to process queued jobs while logging heartbeats
- expose job enqueue/status endpoints and ensure scripts build successfully

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920c77222c483298dce339d3e8ec729)