### PR TITLE
Configure Railway deployment health and runtime settings

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -2,17 +2,12 @@
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
     "builder": "NIXPACKS",
-    "buildCommand": "npm install && npm run build",
-    "startCommand": "npm run start"
-  },
-  "deploy": {
-    "healthcheckPath": "/health",
-    "restartPolicyType": "ON_FAILURE"
     "buildCommand": "npm install && npm run build"
   },
   "deploy": {
-    "startCommand": "npm start",
+    "startCommand": "npm run start",
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 10
+    "restartPolicyMaxRetries": 10,
+    "healthcheckPath": "/api/health"
   }
 }

--- a/railway.toml
+++ b/railway.toml
@@ -3,10 +3,10 @@ builder = "NIXPACKS"
 buildCommand = "npm install && npm run build"
 
 [deploy]
-startCommand = "npm start"
+startCommand = "npm run start"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10
-healthcheckPath = "/health"
+healthcheckPath = "/api/health"
 healthcheckTimeout = 100
 healthcheckInterval = 20
 numReplicas = 1

--- a/src/env.ts
+++ b/src/env.ts
@@ -10,3 +10,21 @@ export function loadEnv(): NodeJS.ProcessEnv {
 
   return process.env;
 }
+
+export function getRuntimeConfig(): {
+  apiUrl?: string;
+  serviceBaseUrl?: string;
+  osRoot?: string;
+  host?: string;
+  port?: string;
+} {
+  const env = loadEnv();
+
+  return {
+    apiUrl: env.API_URL ?? env.CORE_URL ?? env.CORE_API_URL,
+    serviceBaseUrl: env.SERVICE_BASE_URL,
+    osRoot: env.OS_ROOT,
+    host: env.HOST,
+    port: env.PORT,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,10 @@ app.get('/health', (_req, res) => {
   res.json({ status: 'ok', service: 'operator' });
 });
 
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok', service: 'operator' });
+});
+
 app.get('/version', (_req, res) => {
   res.json({ version: packageJson.version, service: 'operator' });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,13 +1,15 @@
 import app from './index';
-import { loadEnv } from './env';
+import { getRuntimeConfig, loadEnv } from './env';
 import { startWorker } from './worker';
 
 loadEnv();
 
-const port = process.env.PORT || 8080;
+const runtimeConfig = getRuntimeConfig();
+const port = Number(runtimeConfig.port ?? process.env.PORT ?? 8080);
+const host = runtimeConfig.host || '0.0.0.0';
 
-const server = app.listen(port, () => {
-  console.log(`BlackRoad OS Operator listening on :${port}`);
+const server = app.listen(port, host, () => {
+  console.log(`BlackRoad OS Operator listening on ${host}:${port}`);
 
   startWorker();
 });


### PR DESCRIPTION
## Summary
- add /api/health endpoint alongside existing health check for the operator service
- ensure server binds to configurable HOST with default 0.0.0.0 and expose runtime env helper for API/CORE URLs
- align Railway build/start commands and healthcheck path with deployment requirements

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920e471b4f08329aa7bdd8fe30f77a5)