### PR TITLE
Add health endpoints and system aggregation

### DIFF
--- a/src/health/config.ts
+++ b/src/health/config.ts
@@ -1,0 +1,34 @@
+import { loadEnv } from '../env';
+
+export type ServiceDefinition = {
+  key: 'core' | 'web' | 'docs' | 'prism-console' | 'operator';
+  envVar: 'CORE_URL' | 'WEB_URL' | 'DOCS_URL' | 'PRISM_CONSOLE_URL' | 'OPERATOR_URL';
+  defaultUrl?: string;
+};
+
+const serviceDefinitions: ServiceDefinition[] = [
+  { key: 'core', envVar: 'CORE_URL', defaultUrl: 'http://localhost:3000' },
+  { key: 'web', envVar: 'WEB_URL', defaultUrl: 'http://localhost:3001' },
+  { key: 'docs', envVar: 'DOCS_URL', defaultUrl: 'http://localhost:3002' },
+  { key: 'prism-console', envVar: 'PRISM_CONSOLE_URL', defaultUrl: 'http://localhost:3003' },
+  { key: 'operator', envVar: 'OPERATOR_URL' },
+];
+
+export function getServiceUrls() {
+  const env = loadEnv();
+  const port = env.PORT ?? '8080';
+
+  return serviceDefinitions.reduce<Record<string, string | undefined>>((acc, definition) => {
+    const defaultUrl =
+      definition.key === 'operator'
+        ? env[definition.envVar] ?? `http://localhost:${port}`
+        : definition.defaultUrl;
+
+    acc[definition.key] = env[definition.envVar] ?? defaultUrl;
+    return acc;
+  }, {});
+}
+
+export function getServiceDefinitions() {
+  return serviceDefinitions;
+}

--- a/src/health/healthClient.ts
+++ b/src/health/healthClient.ts
@@ -1,0 +1,59 @@
+export type ServiceHealthResult = {
+  reachable: boolean;
+  httpStatus: number | null;
+  payload: unknown | null;
+  error?: string;
+};
+
+const DEFAULT_TIMEOUT_MS = 2_000;
+
+async function fetchWithTimeout(url: string, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function checkServiceHealth(serviceName: string, baseUrl?: string): Promise<ServiceHealthResult> {
+  if (!baseUrl) {
+    return {
+      reachable: false,
+      httpStatus: null,
+      payload: null,
+      error: 'Service URL not configured',
+    };
+  }
+
+  const healthUrl = `${baseUrl.replace(/\/$/, '')}/health`;
+
+  try {
+    const response = await fetchWithTimeout(healthUrl);
+    const contentType = response.headers.get('content-type');
+    let payload: unknown = null;
+
+    if (contentType?.includes('application/json')) {
+      payload = await response.json();
+    } else {
+      payload = await response.text();
+    }
+
+    return {
+      reachable: response.ok,
+      httpStatus: response.status,
+      payload,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+
+    return {
+      reachable: false,
+      httpStatus: null,
+      payload: null,
+      error: message,
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,12 @@
 import express from 'express';
-import packageJson from '../package.json';
+import healthRoutes from './routes/healthRoutes';
 import jobsRoutes from './routes/jobsRoutes';
 
 const app = express();
 
 app.use(express.json());
 
-app.get('/health', (_req, res) => {
-  res.json({ status: 'ok', service: 'operator' });
-});
-
-app.get('/api/health', (_req, res) => {
-  res.json({ status: 'ok', service: 'operator' });
-});
-
-app.get('/version', (_req, res) => {
-  res.json({ version: packageJson.version, service: 'operator' });
-});
-
+app.use(healthRoutes);
 app.use('/jobs', jobsRoutes);
 
 export default app;

--- a/src/routes/healthRoutes.ts
+++ b/src/routes/healthRoutes.ts
@@ -1,0 +1,54 @@
+import express from 'express';
+import packageJson from '../../package.json';
+import { getServiceUrls } from '../health/config';
+import { checkServiceHealth } from '../health/healthClient';
+
+const router = express.Router();
+
+const baseHealthResponse = () => ({
+  status: 'ok',
+  service: 'operator',
+  timestamp: new Date().toISOString(),
+});
+
+router.get('/health', (_req, res) => {
+  res.json(baseHealthResponse());
+});
+
+router.get('/api/health', (_req, res) => {
+  res.json(baseHealthResponse());
+});
+
+router.get('/version', (_req, res) => {
+  res.json({ version: packageJson.version, service: 'operator' });
+});
+
+router.get('/system/health', async (_req, res) => {
+  console.log('Received /system/health request');
+  const serviceUrls = getServiceUrls();
+  const results: Record<string, Awaited<ReturnType<typeof checkServiceHealth>>> = {};
+
+  for (const [serviceName, url] of Object.entries(serviceUrls)) {
+    const result = await checkServiceHealth(serviceName, url);
+
+    if (!result.reachable) {
+      console.warn(`Service ${serviceName} unreachable`, result.error ?? result.payload);
+    }
+
+    results[serviceName] = result;
+  }
+
+  const totalServices = Object.keys(results).length;
+  const failures = Object.values(results).filter((result) => !result.reachable || (result.httpStatus ?? 0) >= 300).length;
+
+  const status = failures === 0 ? 'ok' : failures < totalServices ? 'degraded' : 'error';
+
+  res.json({
+    service: 'operator',
+    status,
+    timestamp: new Date().toISOString(),
+    services: results,
+  });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add standardized health endpoints with timestamp responses
- introduce service configuration and health client for downstream checks
- provide aggregated system health reporting across canonical services

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692202d073f08329b89bd99f4fb8086e)