### PR TITLE
Add Bun start script and health endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "dist/server.js",
   "license": "MIT",
   "scripts": {
-    "dev": "tsx src/server.ts",
+    "dev": "bun run src/server.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/server.js",
+    "start": "bun run src/server.ts",
     "lint": "eslint .",
     "dev:worker": "tsx src/worker/index.ts",
     "start:worker": "node dist/worker/index.js"

--- a/src/health/health.ts
+++ b/src/health/health.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from 'express';
+
+export function healthHandler(_req: Request, res: Response) {
+  res.status(200).json({ status: 'ok', service: 'blackroad-os-operator' });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { healthHandler } from './health/health';
 import healthRoutes from './routes/healthRoutes';
 import jobsRoutes from './routes/jobsRoutes';
 
@@ -6,6 +7,7 @@ const app = express();
 
 app.use(express.json());
 
+app.get('/health', healthHandler);
 app.use(healthRoutes);
 app.use('/jobs', jobsRoutes);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,11 +5,11 @@ import { startWorker } from './worker';
 loadEnv();
 
 const runtimeConfig = getRuntimeConfig();
-const port = Number(runtimeConfig.port ?? process.env.PORT ?? 8080);
-const host = runtimeConfig.host || '0.0.0.0';
+const port = Number(process.env.PORT ?? runtimeConfig.port ?? 8080);
+const host = '0.0.0.0';
 
 const server = app.listen(port, host, () => {
-  console.log(`BlackRoad OS Operator listening on ${host}:${port}`);
+  console.log(`[blackroad-os-operator] listening on http://${host}:${port}`);
 
   startWorker();
 });


### PR DESCRIPTION
## Summary
- add Bun-based dev and start scripts for the operator service
- add dedicated /health handler returning service status
- ensure server listens on configurable PORT from all interfaces

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69226c011a8883298370bfa6c4bd2224)