### PR TITLE
Add finance layer scaffolding and orchestrator

### DIFF
--- a/config/finance_agent_registry.yaml
+++ b/config/finance_agent_registry.yaml
@@ -1,0 +1,225 @@
+agents:
+  - id: unified_ledger
+    name: "Unified Ledger & Subledgers Agent"
+    description: "Maintains double-entry accounting ledgers for BlackRoad: general ledger, management ledger, and regulatory ledgers."
+    mandate:
+      - Design and enforce a coherent chart of accounts.
+      - Accept transaction events from across the OS and transform them into balanced journal entries.
+      - Maintain subledgers and reconciliations.
+    inputs:
+      - Transaction events (trades, invoices, subscriptions, expenses, payroll, tax, manual journal entries).
+      - Configuration for chart of accounts and posting rules.
+    outputs:
+      - Journal entries.
+      - Trial balances.
+      - Account balances by period.
+    critical_reports:
+      - period_trial_balance
+      - subledger_reconciliation
+    escalation_rules:
+      - Any structural change to the chart of accounts.
+      - Any back-dated journal entry over a configurable threshold.
+      - Any manual journal entry explicitly flagged as requires_human_approval.
+    dependencies: []
+    data_sources:
+      - Core database.
+      - Event bus.
+    status: experimental
+
+  - id: market_data
+    name: "Market & Reference Data Agent"
+    description: Centralizes instrument reference data and market prices (equities, bonds, funds, FX, rates).
+    mandate:
+      - Maintain an instrument master for all tradable/valued instruments.
+      - Ingest and normalize prices and curves from external sources.
+    inputs:
+      - External price feeds.
+      - Instrument metadata sources.
+    outputs:
+      - Instrument master snapshots.
+      - End-of-day price files.
+      - Yield curves and other reference curves.
+    critical_reports:
+      - market_data_quality_report
+      - stale_feed_alerts
+    escalation_rules:
+      - Change of data vendor.
+      - Data gaps or anomalies exceeding thresholds.
+    dependencies: []
+    data_sources:
+      - External APIs.
+      - Internal DB.
+    status: experimental
+
+  - id: accounting_close
+    name: "Accounting & Close Agent"
+    description: Implements accrual accounting, runs the monthly/quarterly close, and produces financial statements.
+    mandate:
+      - Generate adjusting entries and period-end entries (accruals, deferrals, amortizations).
+      - Produce Income Statement, Balance Sheet, Cash Flow Statement, and Statement of Equity.
+      - Perform variance analysis vs prior periods and budgets.
+    inputs:
+      - Journal entries and account balances from unified_ledger.
+      - Accounting policy configuration.
+    outputs:
+      - Period financial statements.
+      - Adjusting journal entries.
+      - Close checklist status.
+    critical_reports:
+      - period_close_package
+      - variance_analysis
+    escalation_rules:
+      - Any material adjustment above a defined threshold.
+      - Changes to accounting policies.
+      - Detection of errors requiring restatement.
+    dependencies:
+      - unified_ledger
+      - market_data
+    data_sources:
+      - Ledger DB.
+      - Policy config store.
+    status: experimental
+
+  - id: treasury_liquidity
+    name: "Treasury & Liquidity Agent"
+    description: Manages cash, short-term investments, and ensures sufficient liquidity via a rolling forecast.
+    mandate:
+      - Maintain a 13-week rolling cash forecast.
+      - Propose sweeps, short-term investments, or credit facility draws.
+      - Monitor liquidity and covenant metrics.
+    inputs:
+      - Current bank balances and statements.
+      - Payables/receivables schedules.
+      - Forecast data from FP&A.
+    outputs:
+      - Cash forecasts.
+      - Recommended treasury actions.
+    critical_reports:
+      - weekly_cash_forecast
+      - liquidity_and_covenant_report
+    escalation_rules:
+      - Any draw on or amendment to credit facilities.
+      - Breach of minimum liquidity floor.
+      - Any change of core banking relationships.
+    dependencies:
+      - accounting_close
+      - fpna_forecasting
+    data_sources:
+      - Banking APIs.
+      - Internal financial DB.
+    status: experimental
+
+  - id: fpna_forecasting
+    name: "FP&A / Budgeting & Forecasting Agent"
+    description: Maintains rolling financial forecasts and budgets; provides scenario and sensitivity analysis.
+    mandate:
+      - Generate 12–24 month forecasts under base, bull, and bear cases.
+      - Produce pro forma IS/BS/CF and driver-based sensitivities.
+      - Reconcile forecasts to actuals and explain variances.
+    inputs:
+      - Historical financial statements.
+      - Revenue pipeline metrics.
+      - Headcount and compensation plans.
+      - Infrastructure cost curves.
+    outputs:
+      - Forecast models and projections.
+      - Budget vs actual dashboards/feeds.
+    critical_reports:
+      - quarterly_forecast_package
+      - budget_vs_actual_report
+    escalation_rules:
+      - Significant change to core assumptions (growth, churn, pricing, infra cost per user).
+      - Major deviation from forecast.
+    dependencies:
+      - accounting_close
+      - market_data
+    data_sources:
+      - Data warehouse.
+      - CRM / subscription systems.
+    status: experimental
+
+  - id: capital_budgeting
+    name: "Capital Budgeting Agent"
+    description: Evaluates internal projects using NPV/IRR/payback and produces capital allocation recommendations.
+    mandate:
+      - Analyze project cash flows using accepted capital budgeting techniques.
+      - Rank projects by economic value added.
+      - Perform post-implementation reviews when data becomes available.
+    inputs:
+      - Projected cash flows per project.
+      - Discount rates and hurdle rates from capital_structure.
+    outputs:
+      - Project NPV, IRR, payback metrics.
+      - Recommendation (accept/reject/defer).
+    critical_reports:
+      - capital_allocation_recommendation_list
+      - post_implementation_review_summary
+    escalation_rules:
+      - Approval of any project exceeding spend thresholds.
+      - Overrides of negative NPV recommendations.
+    dependencies:
+      - fpna_forecasting
+      - capital_structure
+    data_sources:
+      - Project management systems.
+      - Forecast models.
+    status: experimental
+
+  - id: capital_structure
+    name: "Capital Structure & Funding Agent"
+    description: Manages and recommends the firm’s capital structure and funding strategy.
+    mandate:
+      - Maintain an up-to-date view of debt, equity, and hybrid instruments.
+      - Recommend optimal funding mix and timing of raises.
+      - Calculate and update WACC.
+    inputs:
+      - Current capital structure detail.
+      - Market conditions (rates, valuations).
+      - Forecasts from FP&A.
+    outputs:
+      - Funding proposals.
+      - Capital structure summaries.
+      - WACC estimates.
+    critical_reports:
+      - capital_structure_summary
+      - funding_runway_analysis
+      - dilution_scenarios
+    escalation_rules:
+      - Any external capital raise or new security issuance.
+      - Major leverage change.
+    dependencies:
+      - accounting_close
+      - market_data
+      - fpna_forecasting
+    data_sources:
+      - Internal cap table systems.
+      - Market data feeds.
+    status: experimental
+
+  - id: working_capital
+    name: "Working Capital & Trade Credit Agent"
+    description: Oversees receivables, payables, and inventory (if any) to optimize the cash conversion cycle.
+    mandate:
+      - Monitor DSO, DPO, and DIO.
+      - Propose credit limits and terms for customers and suppliers.
+      - Flag risky or delinquent counterparties.
+    inputs:
+      - AR and AP aging reports.
+      - Customer credit profiles and payment history.
+      - Supplier terms.
+    outputs:
+      - Recommended credit limits and terms.
+      - Working capital KPIs.
+    critical_reports:
+      - monthly_working_capital_report
+      - high_risk_counterparty_list
+    escalation_rules:
+      - Write-offs above a defined threshold.
+      - Changes to standard customer or vendor terms.
+    dependencies:
+      - unified_ledger
+      - treasury_liquidity
+    data_sources:
+      - Billing and AP systems.
+      - Credit data providers.
+    status: experimental

--- a/docs/finance-layer-v1.md
+++ b/docs/finance-layer-v1.md
@@ -1,0 +1,33 @@
+# Finance Layer v1
+
+## Purpose
+The finance layer provides a structured home for finance-oriented agents in BlackRoad OS, including lifecycle management, orchestration, and a registry-backed source of truth for capabilities. This first version prioritizes scaffolding, interfaces, and orchestration hooks over full accounting logic.
+
+## Agents
+- **unified_ledger** — Maintains general, management, and regulatory ledgers; turns events into balanced journal entries.
+- **market_data** — Centralizes instrument master data and market prices.
+- **accounting_close** — Runs accrual accounting and period close processes to produce financial statements.
+- **treasury_liquidity** — Manages rolling cash forecasts, liquidity, and treasury actions.
+- **fpna_forecasting** — Maintains rolling forecasts and budgets with scenario analysis.
+- **capital_budgeting** — Evaluates projects with NPV/IRR/payback to recommend allocations.
+- **capital_structure** — Manages funding mix, WACC, and capital raise recommendations.
+- **working_capital** — Optimizes cash conversion cycle via AR/AP/credit monitoring.
+
+## Registry
+- Located at `config/finance_agent_registry.yaml`.
+- Contains metadata per agent: id, name, description, mandate, inputs, outputs, critical reports, escalation rules, dependencies, data sources, and status.
+- Acts as the single source of truth for orchestration and documentation.
+
+## Adding a New Finance Agent
+1. Add a new entry to `config/finance_agent_registry.yaml` with the required fields.
+2. Create a stub implementation in `src/agents/finance/implemented/<agent_id>_agent.ts` implementing `FinanceAgent`.
+3. Register the constructor in `agentConstructors` inside `src/agents/finance/finance_orchestrator.ts`.
+4. Extend tests under `src/agents/finance/__tests__` to cover registry parsing and orchestrator behavior.
+
+## Future Work
+- GAAP rules engine and accounting policy store.
+- FX and multi-currency handling across ledger and reporting.
+- Direct integrations with banking APIs and billing/AP systems.
+- Project valuation math (NPV/IRR), funding optimization, and dilution modeling.
+- Regulatory and tax layers, including compliance-driven escalation workflows.
+- Hardened config loading and shared event-bus abstraction across operator components.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5",
-        "express": "^4.19.2"
+        "express": "^4.19.2",
+        "yaml": "^2.8.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -19,7 +20,8 @@
         "@typescript-eslint/parser": "^8.12.1",
         "eslint": "^9.5.0",
         "tsx": "^4.15.7",
-        "typescript": "^5.4.5"
+        "typescript": "^5.4.5",
+        "vitest": "^4.0.13"
       },
       "engines": {
         "node": ">=20"
@@ -660,6 +662,13 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -698,6 +707,321 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
+      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
+      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
+      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
+      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
+      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
+      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
+      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
+      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
+      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
+      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
+      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
+      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
+      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
+      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
+      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
+      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
+      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
+      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
+      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
+      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -709,6 +1033,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -718,6 +1053,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1091,6 +1433,117 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.13.tgz",
+      "integrity": "sha512-zYtcnNIBm6yS7Gpr7nFTmq8ncowlMdOJkWLqYvhr/zweY6tFbDkDi8BPPOeHxEtK1rSI69H7Fd4+1sqvEGli6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.13",
+        "@vitest/utils": "4.0.13",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.13.tgz",
+      "integrity": "sha512-eNCwzrI5djoauklwP1fuslHBjrbR8rqIVbvNlAnkq1OTa6XT+lX68mrtPirNM9TnR69XUPt4puBCx2Wexseylg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.13",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.13.tgz",
+      "integrity": "sha512-ooqfze8URWbI2ozOeLDMh8YZxWDpGXoeY3VOgcDnsUxN0jPyPWSUvjPQWqDGCBks+opWlN1E4oP1UYl3C/2EQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.13.tgz",
+      "integrity": "sha512-9IKlAru58wcVaWy7hz6qWPb2QzJTKt+IOVKjAx5vb5rzEFPTL6H4/R9BMvjZ2ppkxKgTrFONEJFtzvnyEpiT+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.13",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.13.tgz",
+      "integrity": "sha512-hb7Usvyika1huG6G6l191qu1urNPsq1iFc2hmdzQY3F5/rTgqQnwwplyf8zoYHkpt7H6rw5UfIw6i/3qf9oSxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.13",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.13.tgz",
+      "integrity": "sha512-hSu+m4se0lDV5yVIcNWqjuncrmBgwaXa2utFLIrBkQCQkt+pSwyZTPFQAZiiF/63j8jYa8uAeUZ3RSfcdWaYWw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.13.tgz",
+      "integrity": "sha512-ydozWyQ4LZuu8rLp47xFUWis5VOKMdHjXCWhs1LuJsTNKww+pTHQNK4e0assIB9K80TxFyskENL6vCu3j34EYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.13",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1172,6 +1625,16 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1289,6 +1752,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
+      "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1488,6 +1961,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -1755,6 +2235,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1772,6 +2262,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -2352,6 +2852,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2463,6 +2973,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -2602,6 +3131,20 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2613,6 +3156,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -2737,6 +3309,48 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
+      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.53.3",
+        "@rollup/rollup-android-arm64": "4.53.3",
+        "@rollup/rollup-darwin-arm64": "4.53.3",
+        "@rollup/rollup-darwin-x64": "4.53.3",
+        "@rollup/rollup-freebsd-arm64": "4.53.3",
+        "@rollup/rollup-freebsd-x64": "4.53.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
+        "@rollup/rollup-linux-arm64-musl": "4.53.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-musl": "4.53.3",
+        "@rollup/rollup-openharmony-arm64": "4.53.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
+        "@rollup/rollup-win32-x64-gnu": "4.53.3",
+        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-parallel": {
@@ -2966,6 +3580,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -2974,6 +3612,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -2999,6 +3644,78 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -3140,6 +3857,207 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.4.tgz",
+      "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.13.tgz",
+      "integrity": "sha512-QSD4I0fN6uZQfftryIXuqvqgBxTvJ3ZNkF6RWECd82YGAYAfhcppBLFXzXJHQAAhVFyYEuFTrq6h0hQqjB7jIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.13",
+        "@vitest/mocker": "4.0.13",
+        "@vitest/pretty-format": "4.0.13",
+        "@vitest/runner": "4.0.13",
+        "@vitest/snapshot": "4.0.13",
+        "@vitest/spy": "4.0.13",
+        "@vitest/utils": "4.0.13",
+        "debug": "^4.4.3",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.13",
+        "@vitest/browser-preview": "4.0.13",
+        "@vitest/browser-webdriverio": "4.0.13",
+        "@vitest/ui": "4.0.13",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3156,6 +4074,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3164,6 +4099,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "build": "tsc -p tsconfig.json",
     "start": "bun run src/server.ts",
     "lint": "eslint .",
+    "test": "vitest",
     "dev:worker": "tsx src/worker/index.ts",
     "start:worker": "node dist/worker/index.js"
   },
   "dependencies": {
     "dotenv": "^16.4.5",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "yaml": "^2.8.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
@@ -22,6 +24,7 @@
     "@typescript-eslint/eslint-plugin": "^8.12.1",
     "@typescript-eslint/parser": "^8.12.1",
     "eslint": "^9.5.0",
+    "vitest": "^4.0.13",
     "tsx": "^4.15.7",
     "typescript": "^5.4.5"
   },

--- a/src/agents/finance/__tests__/finance_orchestrator.test.ts
+++ b/src/agents/finance/__tests__/finance_orchestrator.test.ts
@@ -1,0 +1,117 @@
+import path from 'path';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import {
+  AgentContext,
+  FinanceAgent,
+  FinanceEvent,
+  FinanceReport,
+  loadFinanceAgentRegistry,
+} from '../types';
+import { FinanceOrchestrator, SimpleEventBus } from '../finance_orchestrator';
+
+const registryPath = path.resolve(process.cwd(), 'config/finance_agent_registry.yaml');
+
+function createMockContext(): AgentContext {
+  const logger = {
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  };
+
+  return {
+    logger,
+    config: {
+      get: vi.fn(),
+    },
+    eventBus: new SimpleEventBus(),
+    dataAccess: {
+      query: vi.fn(async () => ({})),
+    },
+    psShaInfinity: {
+      hash: vi.fn(() => 'hash'),
+      journal: vi.fn(async () => undefined),
+    },
+  };
+}
+
+describe('finance agent registry', () => {
+  it('parses registry yaml and exposes expected agent ids', () => {
+    const registry = loadFinanceAgentRegistry(registryPath);
+    const ids = registry.agents.map((entry) => entry.id);
+    expect(ids).toEqual([
+      'unified_ledger',
+      'market_data',
+      'accounting_close',
+      'treasury_liquidity',
+      'fpna_forecasting',
+      'capital_budgeting',
+      'capital_structure',
+      'working_capital',
+    ]);
+  });
+});
+
+describe('FinanceOrchestrator', () => {
+  let ctx: AgentContext;
+  let orchestrator: FinanceOrchestrator;
+
+  beforeEach(async () => {
+    ctx = createMockContext();
+    orchestrator = new FinanceOrchestrator(ctx);
+    await orchestrator.init(registryPath);
+  });
+
+  it('initializes all agents without throwing', () => {
+    const agentIds = orchestrator.getAgents().map((agent) => agent.id);
+    expect(agentIds).toContain('unified_ledger');
+    expect(agentIds).toHaveLength(8);
+  });
+
+  it('routes periodic execution to agents implementing runPeriodic', async () => {
+    const spies = orchestrator
+      .getAgents()
+      .filter((agent) => agent.runPeriodic)
+      .map((agent) => vi.spyOn(agent, 'runPeriodic'));
+
+    await orchestrator.runPeriodic();
+
+    spies.forEach((spy) => {
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  it('collects reports from agents that generate them', async () => {
+    const agents = orchestrator.getAgents();
+    const sampleReport: FinanceReport = {
+      id: 'report-1',
+      agentId: agents[0]?.id ?? 'unknown',
+      type: 'test',
+      createdAt: new Date().toISOString(),
+      data: {},
+    };
+
+    const spy = vi.spyOn(agents[0] as FinanceAgent, 'generateReports');
+    spy.mockResolvedValueOnce([sampleReport]);
+
+    const reports = await orchestrator.collectReports();
+
+    expect(reports).toContainEqual(sampleReport);
+  });
+
+  it('dispatches events to subscribed agents', async () => {
+    const event: FinanceEvent = {
+      id: 'evt-1',
+      type: 'finance.test',
+      source: 'test',
+      timestamp: new Date().toISOString(),
+      payload: {},
+    };
+
+    const agents = orchestrator.getAgents();
+    const spy = vi.spyOn(agents[0], 'handleEvent');
+
+    await orchestrator.broadcastEvent(event);
+
+    expect(spy).toHaveBeenCalledWith(event);
+  });
+});

--- a/src/agents/finance/finance_orchestrator.ts
+++ b/src/agents/finance/finance_orchestrator.ts
@@ -1,0 +1,192 @@
+import { UnifiedLedgerAgent } from './implemented/unified_ledger_agent';
+import { MarketDataAgent } from './implemented/market_data_agent';
+import { AccountingCloseAgent } from './implemented/accounting_close_agent';
+import { TreasuryLiquidityAgent } from './implemented/treasury_liquidity_agent';
+import { FpnaForecastingAgent } from './implemented/fpna_forecasting_agent';
+import { CapitalBudgetingAgent } from './implemented/capital_budgeting_agent';
+import { CapitalStructureAgent } from './implemented/capital_structure_agent';
+import { WorkingCapitalAgent } from './implemented/working_capital_agent';
+import {
+  AgentContext,
+  ConfigProvider,
+  DataAccess,
+  EventBus,
+  FinanceAgent,
+  FinanceAgentRegistry,
+  FinanceEvent,
+  FinanceReport,
+  Logger,
+  loadFinanceAgentRegistry,
+} from './types';
+
+const agentConstructors: Record<string, new () => FinanceAgent> = {
+  unified_ledger: UnifiedLedgerAgent,
+  market_data: MarketDataAgent,
+  accounting_close: AccountingCloseAgent,
+  treasury_liquidity: TreasuryLiquidityAgent,
+  fpna_forecasting: FpnaForecastingAgent,
+  capital_budgeting: CapitalBudgetingAgent,
+  capital_structure: CapitalStructureAgent,
+  working_capital: WorkingCapitalAgent,
+};
+
+type SubscriptionHandler = (event: FinanceEvent) => Promise<void> | void;
+
+export class SimpleEventBus implements EventBus {
+  private subscriptions: Map<string, SubscriptionHandler[]> = new Map();
+
+  subscribe(topic: string, handler: SubscriptionHandler): void {
+    const handlers = this.subscriptions.get(topic) ?? [];
+    handlers.push(handler);
+    this.subscriptions.set(topic, handlers);
+  }
+
+  async publish(topic: string, event: FinanceEvent): Promise<void> {
+    const handlers: SubscriptionHandler[] = [];
+
+    this.subscriptions.forEach((registeredHandlers, registeredTopic) => {
+      if (registeredTopic === topic) {
+        handlers.push(...registeredHandlers);
+        return;
+      }
+
+      if (registeredTopic === '*') {
+        handlers.push(...registeredHandlers);
+        return;
+      }
+
+      if (registeredTopic.endsWith('*')) {
+        const prefix = registeredTopic.slice(0, -1);
+        if (topic.startsWith(prefix)) {
+          handlers.push(...registeredHandlers);
+        }
+      }
+    });
+
+    for (const handler of handlers) {
+      await Promise.resolve(handler(event));
+    }
+  }
+}
+
+export function createConsoleLogger(): Logger {
+  return {
+    info: (payload: unknown, message?: string) => {
+      // eslint-disable-next-line no-console
+      console.info(message ?? '', payload);
+    },
+    debug: (payload: unknown, message?: string) => {
+      // eslint-disable-next-line no-console
+      console.debug(message ?? '', payload);
+    },
+    error: (payload: unknown, message?: string) => {
+      // eslint-disable-next-line no-console
+      console.error(message ?? '', payload);
+    },
+  };
+}
+
+export function createEnvConfigProvider(): ConfigProvider {
+  return {
+    get: <T = unknown>(key: string, defaultValue?: T) =>
+      (process.env[key] as unknown as T) ?? defaultValue,
+  };
+}
+
+export function createNoopDataAccess(): DataAccess {
+  return {
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async query<T = unknown>(): Promise<T> {
+      // TODO: replace with database access integration.
+      return {} as T;
+    },
+  };
+}
+
+export function createInsecurePsShaInfinity() {
+  return {
+    hash: (payload: unknown) => JSON.stringify(payload),
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async journal() {
+      // TODO: connect to journal persistence once available.
+      return;
+    },
+  };
+}
+
+export class FinanceOrchestrator {
+  private ctx: AgentContext;
+
+  private agents: FinanceAgent[] = [];
+
+  private registry?: FinanceAgentRegistry;
+
+  constructor(ctx: AgentContext) {
+    this.ctx = ctx;
+  }
+
+  getAgents(): FinanceAgent[] {
+    return this.agents;
+  }
+
+  getRegistry(): FinanceAgentRegistry | undefined {
+    return this.registry;
+  }
+
+  async init(registryPath?: string): Promise<void> {
+    this.registry = loadFinanceAgentRegistry(registryPath);
+    this.ctx.logger.info({ registryAgents: this.registry.agents.length }, 'FinanceOrchestrator registry loaded');
+
+    for (const entry of this.registry.agents) {
+      const ctor = agentConstructors[entry.id];
+      if (!ctor) {
+        this.ctx.logger.error({ agentId: entry.id }, 'No constructor registered for finance agent');
+        continue;
+      }
+
+      const agent = new ctor();
+      await agent.init(this.ctx);
+      this.agents.push(agent);
+
+      // Subscribe agent to finance-related topics. Wildcard support is implemented in the SimpleEventBus.
+      this.ctx.eventBus.subscribe('finance.*', async (event: FinanceEvent) => agent.handleEvent(event));
+      this.ctx.eventBus.subscribe(`${agent.id}.*`, async (event: FinanceEvent) => agent.handleEvent(event));
+    }
+  }
+
+  async broadcastEvent(event: FinanceEvent): Promise<void> {
+    const topic = event.type ?? 'finance.event';
+    await this.ctx.eventBus.publish(topic, event);
+  }
+
+  async runPeriodic(): Promise<void> {
+    for (const agent of this.agents) {
+      if (agent.runPeriodic) {
+        await agent.runPeriodic();
+      }
+    }
+  }
+
+  async collectReports(): Promise<FinanceReport[]> {
+    const reports: FinanceReport[] = [];
+    for (const agent of this.agents) {
+      if (agent.generateReports) {
+        const generated = await agent.generateReports();
+        reports.push(...generated);
+      }
+    }
+
+    return reports;
+  }
+}
+
+export function createDefaultFinanceAgentContext(): AgentContext {
+  const eventBus = new SimpleEventBus();
+  return {
+    logger: createConsoleLogger(),
+    config: createEnvConfigProvider(),
+    eventBus,
+    dataAccess: createNoopDataAccess(),
+    psShaInfinity: createInsecurePsShaInfinity(),
+  };
+}

--- a/src/agents/finance/implemented/accounting_close_agent.ts
+++ b/src/agents/finance/implemented/accounting_close_agent.ts
@@ -1,0 +1,32 @@
+/**
+ * AccountingCloseAgent orchestrates accrual accounting, month-end close activities, and production of financial statements.
+ * Future iterations will apply accounting policies, generate adjusting entries, and perform automated variance analysis.
+ */
+import { AgentContext, FinanceAgent, FinanceEvent, FinanceReport } from '../types';
+
+export class AccountingCloseAgent implements FinanceAgent {
+  public readonly id = 'accounting_close';
+
+  private ctx!: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info({ agentId: this.id }, 'AccountingCloseAgent initialized');
+    // TODO: load accounting policy configuration and close checklist templates.
+  }
+
+  async handleEvent(event: FinanceEvent): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id, eventType: event.type }, 'AccountingCloseAgent.handleEvent');
+    // TODO: react to ledger updates to prepare period-end entries and supporting schedules.
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id }, 'AccountingCloseAgent.runPeriodic');
+    // TODO: schedule close tasks, reconciliations, and adjusting entries.
+  }
+
+  async generateReports(): Promise<FinanceReport[]> {
+    // TODO: compile period close package and variance analysis outputs.
+    return [];
+  }
+}

--- a/src/agents/finance/implemented/capital_budgeting_agent.ts
+++ b/src/agents/finance/implemented/capital_budgeting_agent.ts
@@ -1,0 +1,32 @@
+/**
+ * CapitalBudgetingAgent evaluates internal projects using NPV, IRR, and payback to inform capital allocation decisions.
+ * Future logic will model project cash flows, rank initiatives, and run post-implementation reviews.
+ */
+import { AgentContext, FinanceAgent, FinanceEvent, FinanceReport } from '../types';
+
+export class CapitalBudgetingAgent implements FinanceAgent {
+  public readonly id = 'capital_budgeting';
+
+  private ctx!: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info({ agentId: this.id }, 'CapitalBudgetingAgent initialized');
+    // TODO: wire discount rate inputs and project data sources.
+  }
+
+  async handleEvent(event: FinanceEvent): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id, eventType: event.type }, 'CapitalBudgetingAgent.handleEvent');
+    // TODO: react to new project proposals and updated cash flow projections.
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id }, 'CapitalBudgetingAgent.runPeriodic');
+    // TODO: refresh rankings and perform post-implementation reviews.
+  }
+
+  async generateReports(): Promise<FinanceReport[]> {
+    // TODO: output capital allocation recommendations and review summaries.
+    return [];
+  }
+}

--- a/src/agents/finance/implemented/capital_structure_agent.ts
+++ b/src/agents/finance/implemented/capital_structure_agent.ts
@@ -1,0 +1,32 @@
+/**
+ * CapitalStructureAgent maintains the firm's funding stack, evaluates leverage, and recommends capital raises or mix changes.
+ * Future work will model WACC, dilution scenarios, and integrate with market data for timing and pricing recommendations.
+ */
+import { AgentContext, FinanceAgent, FinanceEvent, FinanceReport } from '../types';
+
+export class CapitalStructureAgent implements FinanceAgent {
+  public readonly id = 'capital_structure';
+
+  private ctx!: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info({ agentId: this.id }, 'CapitalStructureAgent initialized');
+    // TODO: connect to cap table systems and funding policy configurations.
+  }
+
+  async handleEvent(event: FinanceEvent): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id, eventType: event.type }, 'CapitalStructureAgent.handleEvent');
+    // TODO: react to valuation changes, debt covenants, and fundraising signals.
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id }, 'CapitalStructureAgent.runPeriodic');
+    // TODO: recompute WACC, runway analysis, and dilution scenarios.
+  }
+
+  async generateReports(): Promise<FinanceReport[]> {
+    // TODO: produce capital structure summaries and funding runway analyses.
+    return [];
+  }
+}

--- a/src/agents/finance/implemented/fpna_forecasting_agent.ts
+++ b/src/agents/finance/implemented/fpna_forecasting_agent.ts
@@ -1,0 +1,32 @@
+/**
+ * FpnaForecastingAgent maintains rolling budgets and forecasts, supporting scenario planning and variance explanations.
+ * Future enhancements will incorporate driver-based models, scenario stress testing, and reconciliation to actuals.
+ */
+import { AgentContext, FinanceAgent, FinanceEvent, FinanceReport } from '../types';
+
+export class FpnaForecastingAgent implements FinanceAgent {
+  public readonly id = 'fpna_forecasting';
+
+  private ctx!: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info({ agentId: this.id }, 'FpnaForecastingAgent initialized');
+    // TODO: connect to data warehouse sources and initialize forecasting models.
+  }
+
+  async handleEvent(event: FinanceEvent): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id, eventType: event.type }, 'FpnaForecastingAgent.handleEvent');
+    // TODO: ingest actuals and pipeline events to refresh forecasts and scenarios.
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id }, 'FpnaForecastingAgent.runPeriodic');
+    // TODO: rebuild rolling forecasts and variance reconciliations on a schedule.
+  }
+
+  async generateReports(): Promise<FinanceReport[]> {
+    // TODO: generate quarterly forecast packages and budget vs actuals outputs.
+    return [];
+  }
+}

--- a/src/agents/finance/implemented/market_data_agent.ts
+++ b/src/agents/finance/implemented/market_data_agent.ts
@@ -1,0 +1,32 @@
+/**
+ * MarketDataAgent centralizes instrument master data and market pricing, enabling consistent downstream valuation.
+ * Future work will integrate external vendor feeds, apply data quality checks, and publish normalized curves and price files.
+ */
+import { AgentContext, FinanceAgent, FinanceEvent, FinanceReport } from '../types';
+
+export class MarketDataAgent implements FinanceAgent {
+  public readonly id = 'market_data';
+
+  private ctx!: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info({ agentId: this.id }, 'MarketDataAgent initialized');
+    // TODO: configure vendor connections and schedule price ingestion jobs.
+  }
+
+  async handleEvent(event: FinanceEvent): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id, eventType: event.type }, 'MarketDataAgent.handleEvent');
+    // TODO: react to reference data updates or data quality alerts.
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id }, 'MarketDataAgent.runPeriodic');
+    // TODO: perform periodic price refreshes and stale data detection.
+  }
+
+  async generateReports(): Promise<FinanceReport[]> {
+    // TODO: produce market data quality and stale feed reports.
+    return [];
+  }
+}

--- a/src/agents/finance/implemented/treasury_liquidity_agent.ts
+++ b/src/agents/finance/implemented/treasury_liquidity_agent.ts
@@ -1,0 +1,32 @@
+/**
+ * TreasuryLiquidityAgent manages short-term liquidity, rolling cash forecasts, and treasury actions such as sweeps or credit draws.
+ * Future work will integrate banking APIs, monitor covenants, and recommend funding actions when liquidity thresholds are breached.
+ */
+import { AgentContext, FinanceAgent, FinanceEvent, FinanceReport } from '../types';
+
+export class TreasuryLiquidityAgent implements FinanceAgent {
+  public readonly id = 'treasury_liquidity';
+
+  private ctx!: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info({ agentId: this.id }, 'TreasuryLiquidityAgent initialized');
+    // TODO: load banking connections and initialize liquidity monitoring thresholds.
+  }
+
+  async handleEvent(event: FinanceEvent): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id, eventType: event.type }, 'TreasuryLiquidityAgent.handleEvent');
+    // TODO: react to cash movements, payables/receivables updates, and covenant events.
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id }, 'TreasuryLiquidityAgent.runPeriodic');
+    // TODO: refresh rolling cash forecasts and propose treasury actions.
+  }
+
+  async generateReports(): Promise<FinanceReport[]> {
+    // TODO: assemble weekly cash forecasts and liquidity/covenant reports.
+    return [];
+  }
+}

--- a/src/agents/finance/implemented/unified_ledger_agent.ts
+++ b/src/agents/finance/implemented/unified_ledger_agent.ts
@@ -1,0 +1,33 @@
+/**
+ * UnifiedLedgerAgent maintains double-entry accounting ledgers across general, management, and regulatory books.
+ * Future work will map transaction events into journal entries using GAAP-compliant rules, handle multi-currency support,
+ * and manage reconciliations and subledger consistency across the platform.
+ */
+import { AgentContext, FinanceAgent, FinanceEvent, FinanceReport } from '../types';
+
+export class UnifiedLedgerAgent implements FinanceAgent {
+  public readonly id = 'unified_ledger';
+
+  private ctx!: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info({ agentId: this.id }, 'UnifiedLedgerAgent initialized');
+    // TODO: load chart of accounts configuration and set up persistence layer integration.
+  }
+
+  async handleEvent(event: FinanceEvent): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id, eventType: event.type }, 'UnifiedLedgerAgent.handleEvent');
+    // TODO: transform events into balanced journal entries and persist them through psShaInfinity.journal.
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id }, 'UnifiedLedgerAgent.runPeriodic');
+    // TODO: implement reconciliations, trial balance checks, and aging reports.
+  }
+
+  async generateReports(): Promise<FinanceReport[]> {
+    // TODO: query ledger data stores and assemble trial balances and subledger reconciliations.
+    return [];
+  }
+}

--- a/src/agents/finance/implemented/working_capital_agent.ts
+++ b/src/agents/finance/implemented/working_capital_agent.ts
@@ -1,0 +1,32 @@
+/**
+ * WorkingCapitalAgent monitors receivables, payables, and any inventory to optimize the cash conversion cycle.
+ * Future work will recommend credit terms, flag high-risk counterparties, and drive DSO/DPO/DIO improvements.
+ */
+import { AgentContext, FinanceAgent, FinanceEvent, FinanceReport } from '../types';
+
+export class WorkingCapitalAgent implements FinanceAgent {
+  public readonly id = 'working_capital';
+
+  private ctx!: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info({ agentId: this.id }, 'WorkingCapitalAgent initialized');
+    // TODO: connect to billing, AP, and credit data providers.
+  }
+
+  async handleEvent(event: FinanceEvent): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id, eventType: event.type }, 'WorkingCapitalAgent.handleEvent');
+    // TODO: react to AR/AP updates and recalculate working capital KPIs.
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx.logger.debug({ agentId: this.id }, 'WorkingCapitalAgent.runPeriodic');
+    // TODO: produce monthly working capital reviews and credit recommendations.
+  }
+
+  async generateReports(): Promise<FinanceReport[]> {
+    // TODO: emit working capital reports and high-risk counterparty lists.
+    return [];
+  }
+}

--- a/src/agents/finance/types.ts
+++ b/src/agents/finance/types.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+
+// TODO: Replace these placeholder interfaces with shared implementations once available in the codebase.
+export interface Logger {
+  info(payload: unknown, message?: string): void;
+  debug(payload: unknown, message?: string): void;
+  error(payload: unknown, message?: string): void;
+}
+
+export interface ConfigProvider {
+  get<T = unknown>(key: string, defaultValue?: T): T | undefined;
+}
+
+export interface EventBus {
+  subscribe(topic: string, handler: (event: FinanceEvent) => Promise<void> | void): void;
+  publish(topic: string, event: FinanceEvent): Promise<void>;
+}
+
+export interface DataAccess {
+  query<T = unknown>(queryText: string, params?: unknown[]): Promise<T>;
+}
+
+export interface JournalEntry {
+  id: string;
+  debitAccount: string;
+  creditAccount: string;
+  amount: number;
+  currency: string;
+  memo?: string;
+  timestamp: string;
+}
+
+export interface AgentContext {
+  logger: Logger;
+  config: ConfigProvider;
+  eventBus: EventBus;
+  dataAccess: DataAccess;
+  psShaInfinity: {
+    hash: (payload: unknown) => string;
+    journal: (entry: JournalEntry) => Promise<void>;
+  };
+}
+
+export interface FinanceEvent {
+  id: string;
+  type: string;
+  source: string;
+  timestamp: string;
+  payload: unknown;
+}
+
+export interface FinanceReport {
+  id: string;
+  agentId: string;
+  type: string;
+  period?: string;
+  createdAt: string;
+  data: unknown;
+  metadata?: Record<string, unknown>;
+}
+
+export interface FinanceAgent {
+  id: string;
+  init(ctx: AgentContext): Promise<void>;
+  handleEvent(event: FinanceEvent): Promise<void>;
+  runPeriodic?(): Promise<void>;
+  generateReports?(): Promise<FinanceReport[]>;
+}
+
+export interface FinanceAgentRegistryEntry {
+  id: string;
+  name: string;
+  description: string;
+  mandate: string[];
+  inputs: string[];
+  outputs: string[];
+  critical_reports: string[];
+  escalation_rules: string[];
+  dependencies: string[];
+  data_sources: string[];
+  status: string;
+}
+
+export interface FinanceAgentRegistry {
+  agents: FinanceAgentRegistryEntry[];
+}
+
+export function loadFinanceAgentRegistry(configPath?: string): FinanceAgentRegistry {
+  const resolvedPath =
+    configPath ?? path.resolve(__dirname, '../../../config/finance_agent_registry.yaml');
+  const fileContents = readFileSync(resolvedPath, 'utf-8');
+  // Lazy import to avoid requiring YAML parser globally in environments that do not need it.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { parse } = require('yaml') as { parse: (input: string) => FinanceAgentRegistry };
+  return parse(fileContents);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,16 +1,32 @@
 import app from './index';
 import { getRuntimeConfig, loadEnv } from './env';
 import { startWorker } from './worker';
+import {
+  createDefaultFinanceAgentContext,
+  FinanceOrchestrator,
+} from './agents/finance/finance_orchestrator';
 
 loadEnv();
 
 const runtimeConfig = getRuntimeConfig();
 const port = Number(process.env.PORT ?? runtimeConfig.port ?? 8080);
 const host = '0.0.0.0';
+const financeContext = createDefaultFinanceAgentContext();
+const financeOrchestrator = new FinanceOrchestrator(financeContext);
+
+async function startFinanceLayer(): Promise<void> {
+  try {
+    await financeOrchestrator.init();
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to initialize finance layer', error);
+  }
+}
 
 const server = app.listen(port, host, () => {
   console.log(`[blackroad-os-operator] listening on http://${host}:${port}`);
 
+  void startFinanceLayer();
   startWorker();
 });
 


### PR DESCRIPTION
## Summary
- add a finance agent registry and shared finance interfaces for the operator
- scaffold eight finance agent implementations plus an orchestrator wired to the event bus and server bootstrap
- document the finance layer and provide vitest coverage for registry parsing and orchestrator behavior

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236dde58788329a534c0a71db6fffb)