### PR TITLE
Add operator runtime scaffolding with agents and orchestrators

### DIFF
--- a/docs/agent-lifecycle.md
+++ b/docs/agent-lifecycle.md
@@ -1,0 +1,13 @@
+# Agent Lifecycle
+
+Agents move through a consistent lifecycle that keeps the runtime predictable and auditable.
+
+1. **Load**: The `AgentLoader` reads `agentsRegistry.yaml` and dynamically imports each agent module.
+2. **Init**: `init(ctx)` is called with the shared `AgentContext`, providing logger, event bus, journal, and configuration.
+3. **Subscribe**: Agents may subscribe to events via the injected event bus to react to domain events.
+4. **Run periodic**: If `runPeriodic` is defined, the scheduler invokes it on a configured cadence to perform routine work.
+5. **Handle events**: When events match a subscription, `handleEvent` is invoked to process payloads.
+6. **Journal**: Significant lifecycle steps emit PS-SHA∞ journal entries for downstream auditability.
+7. **Shutdown**: Future hooks will allow graceful teardown and state persistence.
+
+This lifecycle is intentionally lightweight today to allow rapid expansion of new agent pods without heavy ceremony.

--- a/docs/operator-architecture.md
+++ b/docs/operator-architecture.md
@@ -1,0 +1,23 @@
+# Operator Architecture
+
+The operator is the long-lived orchestration layer that runs every BlackRoad OS agent pod. It relies on a typed configuration surface (`src/config`) and a simple runtime (`src/runtime`) that wires together logging, event delivery, scheduling, and journaling via PS-SHA∞.
+
+## Event-driven runtime
+
+Agents communicate via the local event bus (`LocalEventBus`) that supports lightweight publish/subscribe and maintains a small in-memory buffer of recent events for observability. Orchestrators consume agent outputs and can also emit events for downstream consumers.
+
+## Registries
+
+All agent classes are declared in `src/registry/agentsRegistry.yaml`, while orchestrators live in `src/registry/orchestratorsRegistry.yaml`. The loader reads these YAML manifests to dynamically instantiate and initialize modules at startup. This keeps the runtime declarative and ready for future pods.
+
+## Orchestrator layer
+
+Domain orchestrators live in `src/orchestrators`. They sit above their respective agent pods, coordinating cross-agent workflows and journaling actions for compliance. The finance orchestrator is wired by default and schedules daily, weekly, and monthly tasks.
+
+## Startup sequence
+
+1. Load configuration and bootstrap logger.
+2. Initialize event bus and PS-SHA∞ journal implementation.
+3. Build an `AgentContext` and hand it to the `AgentLoader`.
+4. Load agents from the registry, initialize them, and start orchestrator schedules.
+5. Expose internal APIs under `/internal` for inspection and future integrations.

--- a/docs/orchestrators.md
+++ b/docs/orchestrators.md
@@ -1,0 +1,21 @@
+# Orchestrators
+
+Orchestrators coordinate workflows across agent pods. They bundle ordered calls to agents, emit events, and journal important decisions.
+
+## FinanceOrchestrator
+
+`src/orchestrators/financeOrchestrator.ts` demonstrates the pattern:
+
+- `runDailyDataSync` – refreshes market data and ledger snapshots (placeholder).
+- `runWeeklyLiquidity` – drives cash and liquidity analysis.
+- `runMonthlyClose` – coordinates accounting close and reporting.
+- `scheduleDefaults` – attaches default cadences so the orchestrator runs automatically when the operator starts.
+
+## Adding a new orchestrator
+
+1. Create a class in `src/orchestrators` that accepts an `OrchestratorContext`.
+2. Register it in `src/registry/orchestratorsRegistry.yaml`.
+3. Wire schedules using `AgentContext.schedule` to run on the desired cadence.
+4. Expose any internal API endpoints through `src/api` to make results observable.
+
+This structure keeps orchestrations modular and domain-focused while sharing the same runtime primitives.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5",
-        "express": "^4.19.2"
+        "express": "^4.19.2",
+        "js-yaml": "^4.1.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -19,7 +20,8 @@
         "@typescript-eslint/parser": "^8.12.1",
         "eslint": "^9.5.0",
         "tsx": "^4.15.7",
-        "typescript": "^5.4.5"
+        "typescript": "^5.4.5",
+        "vitest": "^1.6.0"
       },
       "engines": {
         "node": ">=20"
@@ -660,6 +662,26 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -697,6 +719,321 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
+      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
+      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
+      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
+      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
+      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
+      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
+      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
+      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
+      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
+      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
+      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
+      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
+      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
+      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
+      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
+      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
+      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
+      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
+      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
+      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -1091,6 +1428,109 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1125,6 +1565,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -1164,7 +1617,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
@@ -1172,6 +1624,16 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1252,6 +1714,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1291,6 +1763,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1306,6 +1797,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/color-convert": {
@@ -1332,6 +1836,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1404,6 +1915,19 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1428,6 +1952,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dotenv": {
@@ -1755,6 +2289,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1772,6 +2316,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/express": {
@@ -2022,6 +2590,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2057,6 +2635,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-tsconfig": {
@@ -2167,6 +2758,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -2264,6 +2865,19 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2271,11 +2885,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2329,6 +2949,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2351,6 +2988,26 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -2378,6 +3035,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -2445,6 +3109,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2458,11 +3135,50 @@
         "node": "*"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -2478,6 +3194,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/object-inspect": {
@@ -2502,6 +3247,22 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -2602,6 +3363,30 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2615,6 +3400,54 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2623,6 +3456,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/proxy-addr": {
@@ -2708,6 +3569,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2737,6 +3605,48 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
+      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.53.3",
+        "@rollup/rollup-android-arm64": "4.53.3",
+        "@rollup/rollup-darwin-arm64": "4.53.3",
+        "@rollup/rollup-darwin-x64": "4.53.3",
+        "@rollup/rollup-freebsd-arm64": "4.53.3",
+        "@rollup/rollup-freebsd-x64": "4.53.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
+        "@rollup/rollup-linux-arm64-musl": "4.53.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-musl": "4.53.3",
+        "@rollup/rollup-openharmony-arm64": "4.53.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
+        "@rollup/rollup-win32-x64-gnu": "4.53.3",
+        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-parallel": {
@@ -2966,6 +3876,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -2973,6 +3920,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2988,6 +3955,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2999,6 +3979,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -3069,6 +4076,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -3095,6 +4112,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -3140,6 +4164,585 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3154,6 +4757,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
     "start": "bun run src/server.ts",
     "lint": "eslint .",
     "dev:worker": "tsx src/worker/index.ts",
-    "start:worker": "node dist/worker/index.js"
+    "start:worker": "node dist/worker/index.js",
+    "test": "vitest run"
   },
   "dependencies": {
     "dotenv": "^16.4.5",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
@@ -23,7 +25,8 @@
     "@typescript-eslint/parser": "^8.12.1",
     "eslint": "^9.5.0",
     "tsx": "^4.15.7",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
   },
   "engines": {
     "node": ">=20"

--- a/src/agents/Agent.ts
+++ b/src/agents/Agent.ts
@@ -1,0 +1,12 @@
+import { AgentContext } from '../runtime/agentContext';
+import { Event } from '../runtime/eventBus';
+
+export interface Agent {
+  id: string;
+  domain: string; // finance, infra, compliance, ops, research
+  description?: string;
+  init(ctx: AgentContext): Promise<void>;
+  handleEvent?(event: Event): Promise<void>;
+  runPeriodic?(): Promise<void>;
+  generateReports?(): Promise<unknown[]>;
+}

--- a/src/agents/compliance/amlAgent.ts
+++ b/src/agents/compliance/amlAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class AmlAgent implements Agent {
+  id = 'aml_agent';
+  domain = AgentDomains.compliance;
+  description = 'Monitors transactions for AML risk.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('AmlAgent initialized');
+  }
+}

--- a/src/agents/compliance/auditTrailAgent.ts
+++ b/src/agents/compliance/auditTrailAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class AuditTrailAgent implements Agent {
+  id = 'audit_trail_agent';
+  domain = AgentDomains.compliance;
+  description = 'Creates supervisory audit trails and evidence.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('AuditTrailAgent initialized');
+  }
+}

--- a/src/agents/compliance/kycAgent.ts
+++ b/src/agents/compliance/kycAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class KycAgent implements Agent {
+  id = 'kyc_agent';
+  domain = AgentDomains.compliance;
+  description = 'Performs KYC verification flows.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('KycAgent initialized');
+  }
+}

--- a/src/agents/compliance/suitabilityAgent.ts
+++ b/src/agents/compliance/suitabilityAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class SuitabilityAgent implements Agent {
+  id = 'suitability_agent';
+  domain = AgentDomains.compliance;
+  description = 'Reviews suitability and appropriateness for offerings.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('SuitabilityAgent initialized');
+  }
+}

--- a/src/agents/compliance/supervisoryAgent.ts
+++ b/src/agents/compliance/supervisoryAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class SupervisoryAgent implements Agent {
+  id = 'supervisory_agent';
+  domain = AgentDomains.compliance;
+  description = 'Oversees compliance workflows and escalations.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('SupervisoryAgent initialized');
+  }
+}

--- a/src/agents/finance/accountingCloseAgent.ts
+++ b/src/agents/finance/accountingCloseAgent.ts
@@ -1,0 +1,24 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class AccountingCloseAgent implements Agent {
+  id = 'accounting_close';
+  domain = AgentDomains.finance;
+  description = 'Coordinates month-end accounting close activities.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('AccountingCloseAgent initialized');
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx?.logger.info('AccountingCloseAgent running close tasks');
+    this.ctx?.journal.record({
+      domain: this.domain,
+      message: 'Ran accounting close periodic tasks',
+      timestamp: Date.now(),
+    });
+  }
+}

--- a/src/agents/finance/capitalBudgetingAgent.ts
+++ b/src/agents/finance/capitalBudgetingAgent.ts
@@ -1,0 +1,19 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class CapitalBudgetingAgent implements Agent {
+  id = 'capital_budgeting';
+  domain = AgentDomains.finance;
+  description = 'Evaluates capital allocation and project ROI.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('CapitalBudgetingAgent initialized');
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx?.logger.debug('CapitalBudgetingAgent running capital checks');
+  }
+}

--- a/src/agents/finance/capitalStructureAgent.ts
+++ b/src/agents/finance/capitalStructureAgent.ts
@@ -1,0 +1,19 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class CapitalStructureAgent implements Agent {
+  id = 'capital_structure';
+  domain = AgentDomains.finance;
+  description = 'Optimizes capital structure, leverage, and cost of capital.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('CapitalStructureAgent initialized');
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx?.logger.debug('CapitalStructureAgent evaluating capital structure');
+  }
+}

--- a/src/agents/finance/fpnaForecastingAgent.ts
+++ b/src/agents/finance/fpnaForecastingAgent.ts
@@ -1,0 +1,19 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class FpnaForecastingAgent implements Agent {
+  id = 'fpna_forecasting';
+  domain = AgentDomains.finance;
+  description = 'Builds rolling forecasts and scenario models.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('FpnaForecastingAgent initialized');
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx?.logger.info('FpnaForecastingAgent refreshing forecasts');
+  }
+}

--- a/src/agents/finance/marketDataAgent.ts
+++ b/src/agents/finance/marketDataAgent.ts
@@ -1,0 +1,19 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class MarketDataAgent implements Agent {
+  id = 'market_data';
+  domain = AgentDomains.finance;
+  description = 'Retrieves and normalizes market/instrument data.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('MarketDataAgent initialized');
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx?.logger.debug('MarketDataAgent fetching market data');
+  }
+}

--- a/src/agents/finance/treasuryLiquidityAgent.ts
+++ b/src/agents/finance/treasuryLiquidityAgent.ts
@@ -1,0 +1,23 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class TreasuryLiquidityAgent implements Agent {
+  id = 'treasury_liquidity';
+  domain = AgentDomains.finance;
+  description = 'Manages liquidity, cash positioning, and forecasts.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('TreasuryLiquidityAgent initialized');
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx?.logger.info('TreasuryLiquidityAgent evaluating liquidity');
+  }
+
+  async generateReports(): Promise<unknown[]> {
+    return [{ message: 'Stub cash forecast', generatedAt: Date.now() }];
+  }
+}

--- a/src/agents/finance/unifiedLedgerAgent.ts
+++ b/src/agents/finance/unifiedLedgerAgent.ts
@@ -1,0 +1,29 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+import { Event } from '../../runtime/eventBus';
+
+export default class UnifiedLedgerAgent implements Agent {
+  id = 'unified_ledger';
+  domain = AgentDomains.finance;
+  description = 'Maintains general ledger, subledgers, and journal events.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('UnifiedLedgerAgent initialized');
+  }
+
+  async handleEvent(event: Event): Promise<void> {
+    this.ctx?.logger.debug('UnifiedLedgerAgent handling event', event.type);
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx?.logger.info('UnifiedLedgerAgent periodic check');
+    this.ctx?.journal.record({
+      domain: this.domain,
+      message: 'Ledger periodic maintenance',
+      timestamp: Date.now(),
+    });
+  }
+}

--- a/src/agents/finance/workingCapitalAgent.ts
+++ b/src/agents/finance/workingCapitalAgent.ts
@@ -1,0 +1,19 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class WorkingCapitalAgent implements Agent {
+  id = 'working_capital';
+  domain = AgentDomains.finance;
+  description = 'Optimizes receivables, payables, and inventory cycles.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('WorkingCapitalAgent initialized');
+  }
+
+  async runPeriodic(): Promise<void> {
+    this.ctx?.logger.debug('WorkingCapitalAgent analyzing working capital');
+  }
+}

--- a/src/agents/infra/dnsAgent.ts
+++ b/src/agents/infra/dnsAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class DnsAgent implements Agent {
+  id = 'dns_agent';
+  domain = AgentDomains.infra;
+  description = 'Manages DNS records and routing updates.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('DnsAgent initialized');
+  }
+}

--- a/src/agents/infra/infraProvisionAgent.ts
+++ b/src/agents/infra/infraProvisionAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class InfraProvisionAgent implements Agent {
+  id = 'infra_provision';
+  domain = AgentDomains.infra;
+  description = 'Provisions compute, storage, and network resources.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('InfraProvisionAgent initialized');
+  }
+}

--- a/src/agents/infra/monitoringAgent.ts
+++ b/src/agents/infra/monitoringAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class MonitoringAgent implements Agent {
+  id = 'monitoring_agent';
+  domain = AgentDomains.infra;
+  description = 'Collects metrics and emits alerts.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('MonitoringAgent initialized');
+  }
+}

--- a/src/agents/infra/secretsAgent.ts
+++ b/src/agents/infra/secretsAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class SecretsAgent implements Agent {
+  id = 'secrets_agent';
+  domain = AgentDomains.infra;
+  description = 'Manages secrets rotation and access policies.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('SecretsAgent initialized');
+  }
+}

--- a/src/agents/ops/healthcheckAgent.ts
+++ b/src/agents/ops/healthcheckAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class HealthcheckAgent implements Agent {
+  id = 'healthcheck_agent';
+  domain = AgentDomains.ops;
+  description = 'Performs system health checks across agents.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('HealthcheckAgent initialized');
+  }
+}

--- a/src/agents/ops/incidentResponseAgent.ts
+++ b/src/agents/ops/incidentResponseAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class IncidentResponseAgent implements Agent {
+  id = 'incident_response';
+  domain = AgentDomains.ops;
+  description = 'Coordinates incident response playbooks.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('IncidentResponseAgent initialized');
+  }
+}

--- a/src/agents/ops/notificationAgent.ts
+++ b/src/agents/ops/notificationAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class NotificationAgent implements Agent {
+  id = 'notification_agent';
+  domain = AgentDomains.ops;
+  description = 'Routes notifications to downstream systems.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('NotificationAgent initialized');
+  }
+}

--- a/src/agents/ops/schedulerAgent.ts
+++ b/src/agents/ops/schedulerAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class SchedulerAgent implements Agent {
+  id = 'scheduler';
+  domain = AgentDomains.ops;
+  description = 'Coordinates timed tasks across domains.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('SchedulerAgent initialized');
+  }
+}

--- a/src/agents/research/insightsAgent.ts
+++ b/src/agents/research/insightsAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class InsightsAgent implements Agent {
+  id = 'insights_agent';
+  domain = AgentDomains.research;
+  description = 'Generates insights and dashboards for stakeholders.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('InsightsAgent initialized');
+  }
+}

--- a/src/agents/research/marketIntelAgent.ts
+++ b/src/agents/research/marketIntelAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class MarketIntelAgent implements Agent {
+  id = 'market_intel_agent';
+  domain = AgentDomains.research;
+  description = 'Tracks market intelligence and competitor moves.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('MarketIntelAgent initialized');
+  }
+}

--- a/src/agents/research/modelTrainingAgent.ts
+++ b/src/agents/research/modelTrainingAgent.ts
@@ -1,0 +1,15 @@
+import { Agent } from '../Agent';
+import { AgentContext } from '../../runtime/agentContext';
+import { AgentDomains } from '../../config/symbols';
+
+export default class ModelTrainingAgent implements Agent {
+  id = 'model_training';
+  domain = AgentDomains.research;
+  description = 'Handles model training pipelines.';
+  private ctx?: AgentContext;
+
+  async init(ctx: AgentContext): Promise<void> {
+    this.ctx = ctx;
+    this.ctx.logger.info('ModelTrainingAgent initialized');
+  }
+}

--- a/src/api/agentsEndpoints.ts
+++ b/src/api/agentsEndpoints.ts
@@ -1,0 +1,27 @@
+import { Router } from 'express';
+import { AgentLoader } from '../runtime/agentLoader';
+
+export function registerAgentsEndpoints(router: Router, loader: AgentLoader) {
+  router.get('/agents', (_req, res) => {
+    const agents = loader.getAgents().map((agent) => ({
+      id: agent.id,
+      domain: agent.domain,
+      description: agent.description,
+    }));
+    res.json({ agents });
+  });
+
+  router.get('/agents/:id', (req, res) => {
+    const agent = loader.getAgent(req.params.id);
+    if (!agent) {
+      res.status(404).json({ error: 'Agent not found' });
+      return;
+    }
+
+    res.json({
+      id: agent.id,
+      domain: agent.domain,
+      description: agent.description,
+    });
+  });
+}

--- a/src/api/financeEndpoints.ts
+++ b/src/api/financeEndpoints.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import { FinanceOrchestrator } from '../orchestrators/financeOrchestrator';
+
+export function registerFinanceEndpoints(router: Router, orchestrator: FinanceOrchestrator) {
+  router.get('/finance/summary', async (_req, res) => {
+    res.json({ status: 'ok', message: 'Finance summary placeholder' });
+  });
+
+  router.get('/finance/cash-forecast', async (_req, res) => {
+    const reports = await orchestrator
+      .runWeeklyLiquidity()
+      .then(() => ({ forecast: 'stub', generatedAt: Date.now() }));
+    res.json(reports);
+  });
+
+  router.get('/finance/statements/:period', async (req, res) => {
+    const { period } = req.params;
+    await orchestrator.runMonthlyClose();
+    res.json({ period, status: 'stub', generatedAt: Date.now() });
+  });
+}

--- a/src/api/internalRouter.ts
+++ b/src/api/internalRouter.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import { FinanceOrchestrator } from '../orchestrators/financeOrchestrator';
+import { AgentLoader } from '../runtime/agentLoader';
+import { EventBus } from '../runtime/eventBus';
+import { registerFinanceEndpoints } from './financeEndpoints';
+import { registerAgentsEndpoints } from './agentsEndpoints';
+
+export interface InternalApiDeps {
+  loader: AgentLoader;
+  financeOrchestrator: FinanceOrchestrator;
+  eventBus: EventBus;
+}
+
+export function createInternalRouter(deps: InternalApiDeps): Router {
+  const router = Router();
+  registerFinanceEndpoints(router, deps.financeOrchestrator);
+  registerAgentsEndpoints(router, deps.loader);
+
+  router.get('/events', (_req, res) => {
+    res.json({ events: deps.eventBus.getRecentEvents() });
+  });
+
+  return router;
+}

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,0 +1,23 @@
+import { DAY, HOUR, MINUTE } from '../utils/time';
+
+export const SchedulerDefaults = {
+  finance: {
+    dailyDataSyncMs: DAY,
+    weeklyLiquidityMs: 7 * DAY,
+    monthlyCloseMs: 30 * DAY,
+  },
+  ops: {
+    healthcheckMs: 5 * MINUTE,
+  },
+};
+
+export const RetryDefaults = {
+  short: 3,
+  medium: 5,
+  long: 7,
+};
+
+export const RegistryPaths = {
+  agents: 'src/registry/agentsRegistry.yaml',
+  orchestrators: 'src/registry/orchestratorsRegistry.yaml',
+};

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,35 @@
+import { config } from 'dotenv';
+
+export interface OperatorConfig {
+  port: number;
+  logLevel: 'debug' | 'info' | 'warn' | 'error';
+  financeEnabled: boolean;
+  operatorEnv: 'dev' | 'staging' | 'prod';
+  dbUrl?: string;
+}
+
+let loaded = false;
+
+export function loadEnv(): void {
+  if (!loaded) {
+    config();
+    loaded = true;
+  }
+}
+
+export function getOperatorConfig(): OperatorConfig {
+  loadEnv();
+  const port = Number(process.env.PORT ?? 8080);
+  const logLevel = (process.env.LOG_LEVEL as OperatorConfig['logLevel']) ?? 'info';
+  const financeEnabled = (process.env.FINANCE_ENABLED ?? 'true').toLowerCase() !== 'false';
+  const operatorEnv = (process.env.OPERATOR_ENV as OperatorConfig['operatorEnv']) ?? 'dev';
+  const dbUrl = process.env.DB_URL;
+
+  return {
+    port,
+    logLevel,
+    financeEnabled,
+    operatorEnv,
+    dbUrl,
+  };
+}

--- a/src/config/symbols.ts
+++ b/src/config/symbols.ts
@@ -1,0 +1,28 @@
+export const AgentDomains = {
+  finance: 'finance',
+  infra: 'infra',
+  compliance: 'compliance',
+  ops: 'ops',
+  research: 'research',
+} as const;
+
+export type AgentDomain = (typeof AgentDomains)[keyof typeof AgentDomains];
+
+export const OrchestratorNames = {
+  finance: 'financeOrchestrator',
+  infra: 'infraOrchestrator',
+  compliance: 'complianceOrchestrator',
+  ops: 'opsOrchestrator',
+  research: 'researchOrchestrator',
+} as const;
+
+export type OrchestratorName = (typeof OrchestratorNames)[keyof typeof OrchestratorNames];
+
+export const TaskTypes = {
+  monthlyClose: 'monthly_close',
+  weeklyLiquidity: 'weekly_liquidity',
+  dailySync: 'daily_sync',
+  heartbeat: 'heartbeat',
+} as const;
+
+export type TaskType = (typeof TaskTypes)[keyof typeof TaskTypes];

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,15 @@ import express from 'express';
 import { healthHandler } from './health/health';
 import healthRoutes from './routes/healthRoutes';
 import jobsRoutes from './routes/jobsRoutes';
+import { createInternalRouter } from './api/internalRouter';
+import { AgentLoader } from './runtime/agentLoader';
+import { LocalEventBus } from './runtime/eventBus';
+import { DevPsShaInfinity } from './runtime/journal';
+import { createLogger } from './utils/logger';
+import { getOperatorConfig, loadEnv } from './config/env';
+import { FinanceOrchestrator } from './orchestrators/financeOrchestrator';
+import { RegistryPaths } from './config/defaults';
+import { AgentContext } from './runtime/agentContext';
 
 const app = express();
 
@@ -10,5 +19,34 @@ app.use(express.json());
 app.get('/health', healthHandler);
 app.use(healthRoutes);
 app.use('/jobs', jobsRoutes);
+
+loadEnv();
+const config = getOperatorConfig();
+const logger = createLogger(config.logLevel);
+const eventBus = new LocalEventBus(logger);
+const journal = new DevPsShaInfinity();
+
+const ctx: AgentContext = {
+  logger,
+  eventBus,
+  journal,
+  config,
+  schedule: (interval, fn) => setInterval(() => fn().catch(logger.error), interval),
+};
+
+const loader = new AgentLoader(ctx);
+const financeOrchestrator = new FinanceOrchestrator({ ctx });
+
+loader
+  .loadFromRegistry(RegistryPaths.agents)
+  .then(() => loader.initAll())
+  .then(() => financeOrchestrator.scheduleDefaults())
+  .then(() => {
+    app.use('/internal', createInternalRouter({ loader, financeOrchestrator, eventBus }));
+    logger.info('Internal API ready');
+  })
+  .catch((err) => {
+    logger.error('Failed to initialize runtime', err);
+  });
 
 export default app;

--- a/src/orchestrators/complianceOrchestrator.ts
+++ b/src/orchestrators/complianceOrchestrator.ts
@@ -1,0 +1,19 @@
+import { AgentDomains } from '../config/symbols';
+import { OrchestratorContext } from './types';
+
+export class ComplianceOrchestrator {
+  private ctx;
+
+  constructor(context: OrchestratorContext) {
+    this.ctx = context.ctx;
+  }
+
+  async performSurveillanceSweep(): Promise<void> {
+    this.ctx.logger.info('[ComplianceOrchestrator] running surveillance sweep');
+    this.ctx.journal.record({
+      domain: AgentDomains.compliance,
+      message: 'compliance_sweep',
+      timestamp: Date.now(),
+    });
+  }
+}

--- a/src/orchestrators/financeOrchestrator.ts
+++ b/src/orchestrators/financeOrchestrator.ts
@@ -1,0 +1,53 @@
+import { AgentDomains, TaskTypes } from '../config/symbols';
+import { SchedulerDefaults } from '../config/defaults';
+import { Agent } from '../agents/Agent';
+import { OrchestratorContext } from './types';
+
+export class FinanceOrchestrator {
+  private ctx;
+
+  constructor(context: OrchestratorContext) {
+    this.ctx = context.ctx;
+  }
+
+  private getAgent(id: string): Agent | undefined {
+    // Placeholder for future agent discovery
+    return undefined;
+  }
+
+  async runMonthlyClose(): Promise<void> {
+    this.ctx.logger.info('[FinanceOrchestrator] runMonthlyClose');
+    // TODO: Trigger accounting close flows and reporting
+    this.ctx.journal.record({
+      domain: AgentDomains.finance,
+      message: TaskTypes.monthlyClose,
+      timestamp: Date.now(),
+    });
+  }
+
+  async runWeeklyLiquidity(): Promise<void> {
+    this.ctx.logger.info('[FinanceOrchestrator] runWeeklyLiquidity');
+    // TODO: Trigger treasury and cash positioning workflows
+    this.ctx.journal.record({
+      domain: AgentDomains.finance,
+      message: TaskTypes.weeklyLiquidity,
+      timestamp: Date.now(),
+    });
+  }
+
+  async runDailyDataSync(): Promise<void> {
+    this.ctx.logger.info('[FinanceOrchestrator] runDailyDataSync');
+    // TODO: Trigger market data syncs and ledger refreshes
+    this.ctx.journal.record({
+      domain: AgentDomains.finance,
+      message: TaskTypes.dailySync,
+      timestamp: Date.now(),
+    });
+  }
+
+  scheduleDefaults(): void {
+    this.ctx.schedule(SchedulerDefaults.finance.dailyDataSyncMs, () => this.runDailyDataSync());
+    this.ctx.schedule(SchedulerDefaults.finance.weeklyLiquidityMs, () => this.runWeeklyLiquidity());
+    this.ctx.schedule(SchedulerDefaults.finance.monthlyCloseMs, () => this.runMonthlyClose());
+  }
+}

--- a/src/orchestrators/infraOrchestrator.ts
+++ b/src/orchestrators/infraOrchestrator.ts
@@ -1,0 +1,19 @@
+import { AgentDomains } from '../config/symbols';
+import { OrchestratorContext } from './types';
+
+export class InfraOrchestrator {
+  private ctx;
+
+  constructor(context: OrchestratorContext) {
+    this.ctx = context.ctx;
+  }
+
+  async reconcileInfrastructure(): Promise<void> {
+    this.ctx.logger.info('[InfraOrchestrator] reconciling infra state');
+    this.ctx.journal.record({
+      domain: AgentDomains.infra,
+      message: 'reconcile_infra',
+      timestamp: Date.now(),
+    });
+  }
+}

--- a/src/orchestrators/opsOrchestrator.ts
+++ b/src/orchestrators/opsOrchestrator.ts
@@ -1,0 +1,19 @@
+import { AgentDomains } from '../config/symbols';
+import { OrchestratorContext } from './types';
+
+export class OpsOrchestrator {
+  private ctx;
+
+  constructor(context: OrchestratorContext) {
+    this.ctx = context.ctx;
+  }
+
+  async performHeartbeat(): Promise<void> {
+    this.ctx.logger.info('[OpsOrchestrator] heartbeat check');
+    this.ctx.journal.record({
+      domain: AgentDomains.ops,
+      message: 'ops_heartbeat',
+      timestamp: Date.now(),
+    });
+  }
+}

--- a/src/orchestrators/researchOrchestrator.ts
+++ b/src/orchestrators/researchOrchestrator.ts
@@ -1,0 +1,19 @@
+import { AgentDomains } from '../config/symbols';
+import { OrchestratorContext } from './types';
+
+export class ResearchOrchestrator {
+  private ctx;
+
+  constructor(context: OrchestratorContext) {
+    this.ctx = context.ctx;
+  }
+
+  async refreshInsights(): Promise<void> {
+    this.ctx.logger.info('[ResearchOrchestrator] refreshing insights');
+    this.ctx.journal.record({
+      domain: AgentDomains.research,
+      message: 'refresh_insights',
+      timestamp: Date.now(),
+    });
+  }
+}

--- a/src/orchestrators/types.ts
+++ b/src/orchestrators/types.ts
@@ -1,0 +1,5 @@
+import { AgentContext } from '../runtime/agentContext';
+
+export interface OrchestratorContext {
+  ctx: AgentContext;
+}

--- a/src/registry/agentsRegistry.yaml
+++ b/src/registry/agentsRegistry.yaml
@@ -1,0 +1,95 @@
+agents:
+  # FINANCE LAYER
+  - id: unified_ledger
+    file: "agents/finance/unifiedLedgerAgent"
+    domain: finance
+    description: Maintains general ledger, subledgers, and journal events.
+
+  - id: market_data
+    file: "agents/finance/marketDataAgent"
+    domain: finance
+    description: Retrieves and normalizes market/instrument data.
+
+  - id: accounting_close
+    file: "agents/finance/accountingCloseAgent"
+    domain: finance
+
+  - id: treasury_liquidity
+    file: "agents/finance/treasuryLiquidityAgent"
+    domain: finance
+
+  - id: fpna_forecasting
+    file: "agents/finance/fpnaForecastingAgent"
+    domain: finance
+
+  - id: capital_budgeting
+    file: "agents/finance/capitalBudgetingAgent"
+    domain: finance
+
+  - id: capital_structure
+    file: "agents/finance/capitalStructureAgent"
+    domain: finance
+
+  - id: working_capital
+    file: "agents/finance/workingCapitalAgent"
+    domain: finance
+
+  # INFRA LAYER
+  - id: infra_provision
+    file: "agents/infra/infraProvisionAgent"
+    domain: infra
+
+  - id: dns_agent
+    file: "agents/infra/dnsAgent"
+    domain: infra
+
+  - id: monitoring_agent
+    file: "agents/infra/monitoringAgent"
+    domain: infra
+
+  - id: secrets_agent
+    file: "agents/infra/secretsAgent"
+    domain: infra
+
+  # COMPLIANCE LAYER
+  - id: aml_agent
+    file: "agents/compliance/amlAgent"
+    domain: compliance
+
+  - id: kyc_agent
+    file: "agents/compliance/kycAgent"
+    domain: compliance
+
+  - id: suitability_agent
+    file: "agents/compliance/suitabilityAgent"
+    domain: compliance
+
+  - id: supervisory_agent
+    file: "agents/compliance/supervisoryAgent"
+    domain: compliance
+
+  # OPS LAYER
+  - id: scheduler
+    file: "agents/ops/schedulerAgent"
+    domain: ops
+
+  - id: notification_agent
+    file: "agents/ops/notificationAgent"
+    domain: ops
+
+  - id: incident_response
+    file: "agents/ops/incidentResponseAgent"
+    domain: ops
+
+  # RESEARCH LAYER
+  - id: model_training
+    file: "agents/research/modelTrainingAgent"
+    domain: research
+
+  - id: insights_agent
+    file: "agents/research/insightsAgent"
+    domain: research
+
+  - id: market_intel_agent
+    file: "agents/research/marketIntelAgent"
+    domain: research

--- a/src/registry/orchestratorsRegistry.yaml
+++ b/src/registry/orchestratorsRegistry.yaml
@@ -1,0 +1,20 @@
+orchestrators:
+  - id: finance_orchestrator
+    file: "orchestrators/financeOrchestrator"
+    description: Coordinates cross-finance workflows.
+
+  - id: infra_orchestrator
+    file: "orchestrators/infraOrchestrator"
+    description: Ensures infrastructure posture and reconciliations.
+
+  - id: compliance_orchestrator
+    file: "orchestrators/complianceOrchestrator"
+    description: Runs periodic surveillance and control checks.
+
+  - id: ops_orchestrator
+    file: "orchestrators/opsOrchestrator"
+    description: Oversees platform operations and heartbeats.
+
+  - id: research_orchestrator
+    file: "orchestrators/researchOrchestrator"
+    description: Coordinates research workloads and insights refreshes.

--- a/src/runtime/agentContext.ts
+++ b/src/runtime/agentContext.ts
@@ -1,0 +1,17 @@
+import { OperatorConfig } from '../config/env';
+import { EventBus } from './eventBus';
+import { PsShaInfinity } from './journal';
+import { Logger } from '../utils/logger';
+
+export interface DataAccess {
+  query: (statement: string, params?: unknown[]) => Promise<unknown>;
+}
+
+export interface AgentContext {
+  logger: Logger;
+  eventBus: EventBus;
+  journal: PsShaInfinity;
+  config: OperatorConfig;
+  db?: DataAccess; // optional for future
+  schedule: (intervalMs: number, fn: () => Promise<void>) => void;
+}

--- a/src/runtime/agentLoader.ts
+++ b/src/runtime/agentLoader.ts
@@ -1,0 +1,80 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { Agent } from '../agents/Agent';
+import { AgentContext } from './agentContext';
+import { EventBus } from './eventBus';
+
+interface AgentRegistryEntry {
+  id: string;
+  file: string;
+  domain: string;
+  description?: string;
+}
+
+interface AgentRegistryFile {
+  agents: AgentRegistryEntry[];
+}
+
+export class AgentLoader {
+  private agents: Map<string, Agent> = new Map();
+  constructor(private ctx: AgentContext) {}
+
+  async loadFromRegistry(registryPath: string): Promise<void> {
+    const absolutePath = path.isAbsolute(registryPath)
+      ? registryPath
+      : path.join(process.cwd(), registryPath);
+    const raw = fs.readFileSync(absolutePath, 'utf8');
+    const parsed = yaml.load(raw) as AgentRegistryFile;
+
+    for (const entry of parsed.agents) {
+      const agent = await this.instantiate(entry);
+      this.agents.set(entry.id, agent);
+    }
+  }
+
+  private async instantiate(entry: AgentRegistryEntry): Promise<Agent> {
+    const filePath = path.join(process.cwd(), 'src', entry.file);
+    const module = await import(filePath);
+    const AgentClass = module.default ?? Object.values(module)[0];
+    const agent: Agent = new AgentClass();
+    agent.id = entry.id;
+    agent.domain = entry.domain;
+    agent.description = entry.description ?? agent.description;
+    return agent;
+  }
+
+  async initAll(): Promise<void> {
+    for (const agent of this.agents.values()) {
+      await agent.init(this.ctx);
+    }
+  }
+
+  async startAllAgents(): Promise<void> {
+    for (const agent of this.agents.values()) {
+      if (agent.runPeriodic) {
+        this.ctx.schedule(60 * 1000, () => agent.runPeriodic!());
+      }
+    }
+  }
+
+  async stopAllAgents(): Promise<void> {
+    // Placeholder for future graceful shutdown hooks
+  }
+
+  getAgents(): Agent[] {
+    return Array.from(this.agents.values());
+  }
+
+  getAgent(id: string): Agent | undefined {
+    return this.agents.get(id);
+  }
+
+  subscribeAgents(eventBus: EventBus): void {
+    for (const agent of this.agents.values()) {
+      if (agent.handleEvent) {
+        eventBus.subscribe('*', (event) => agent.handleEvent?.(event));
+      }
+    }
+  }
+}

--- a/src/runtime/eventBus.ts
+++ b/src/runtime/eventBus.ts
@@ -1,0 +1,52 @@
+import { Logger } from '../utils/logger';
+
+export interface Event<TPayload = unknown> {
+  type: string;
+  domain?: string;
+  payload?: TPayload;
+  timestamp: number;
+}
+
+export interface EventSubscription {
+  unsubscribe: () => void;
+}
+
+export interface EventBus {
+  publish: (event: Event) => void;
+  subscribe: (type: string, handler: (event: Event) => void) => EventSubscription;
+  getRecentEvents: () => Event[];
+}
+
+export class LocalEventBus implements EventBus {
+  private listeners: Map<string, Set<(event: Event) => void>> = new Map();
+  private recentEvents: Event[] = [];
+  constructor(private logger?: Logger) {}
+
+  publish(event: Event): void {
+    this.recentEvents = [...this.recentEvents.slice(-99), event];
+    const handlers = [
+      ...(this.listeners.get(event.type) ?? []),
+      ...(this.listeners.get('*') ?? []),
+    ];
+    handlers.forEach((handler) => {
+      try {
+        handler(event);
+      } catch (err) {
+        this.logger?.error?.('Event handler error', err);
+      }
+    });
+  }
+
+  subscribe(type: string, handler: (event: Event) => void): EventSubscription {
+    const handlers = this.listeners.get(type) ?? new Set();
+    handlers.add(handler);
+    this.listeners.set(type, handlers);
+    return {
+      unsubscribe: () => handlers.delete(handler),
+    };
+  }
+
+  getRecentEvents(): Event[] {
+    return [...this.recentEvents];
+  }
+}

--- a/src/runtime/journal.ts
+++ b/src/runtime/journal.ts
@@ -1,0 +1,23 @@
+export interface JournalEntry {
+  domain: string;
+  message: string;
+  timestamp: number;
+  meta?: Record<string, unknown>;
+}
+
+export interface PsShaInfinity {
+  record: (entry: JournalEntry) => void;
+  recent: () => JournalEntry[];
+}
+
+export class DevPsShaInfinity implements PsShaInfinity {
+  private entries: JournalEntry[] = [];
+
+  record(entry: JournalEntry): void {
+    this.entries.push(entry);
+  }
+
+  recent(): JournalEntry[] {
+    return [...this.entries];
+  }
+}

--- a/src/runtime/operatorMain.ts
+++ b/src/runtime/operatorMain.ts
@@ -1,0 +1,39 @@
+import { getOperatorConfig, loadEnv } from '../config/env';
+import { createLogger } from '../utils/logger';
+import { LocalEventBus } from './eventBus';
+import { DevPsShaInfinity } from './journal';
+import { AgentContext } from './agentContext';
+import { AgentLoader } from './agentLoader';
+import { FinanceOrchestrator } from '../orchestrators/financeOrchestrator';
+import { RegistryPaths } from '../config/defaults';
+
+async function main() {
+  loadEnv();
+  const config = getOperatorConfig();
+  const logger = createLogger(config.logLevel);
+
+  const eventBus = new LocalEventBus(logger);
+  const journal = new DevPsShaInfinity();
+
+  const ctx: AgentContext = {
+    logger,
+    eventBus,
+    journal,
+    config,
+    schedule: (interval, fn) => setInterval(() => fn().catch(logger.error), interval),
+  };
+
+  const loader = new AgentLoader(ctx);
+  await loader.loadFromRegistry(RegistryPaths.agents);
+  await loader.initAll();
+
+  const financeOrchestrator = new FinanceOrchestrator({ ctx });
+  financeOrchestrator.scheduleDefaults();
+
+  logger.info('BlackRoad Operator is running.');
+}
+
+main().catch((err) => {
+  console.error('Fatal error starting operator:', err);
+  process.exit(1);
+});

--- a/src/runtime/systemScheduler.ts
+++ b/src/runtime/systemScheduler.ts
@@ -1,0 +1,40 @@
+import { handleAsyncError } from '../utils/errorHandling';
+import { Logger } from '../utils/logger';
+
+export interface ScheduledTask {
+  id: string;
+  intervalMs: number;
+  cancel: () => void;
+}
+
+export class SystemScheduler {
+  private tasks: Map<string, ScheduledTask> = new Map();
+  constructor(private logger: Logger) {}
+
+  schedule(id: string, intervalMs: number, fn: () => Promise<void>): ScheduledTask {
+    if (this.tasks.has(id)) {
+      this.cancel(id);
+    }
+    const timer = setInterval(() => fn().catch(handleAsyncError(this.logger, id)), intervalMs);
+    const task: ScheduledTask = {
+      id,
+      intervalMs,
+      cancel: () => clearInterval(timer),
+    };
+    this.tasks.set(id, task);
+    return task;
+  }
+
+  cancel(id: string): void {
+    const existing = this.tasks.get(id);
+    if (existing) {
+      existing.cancel();
+      this.tasks.delete(id);
+    }
+  }
+
+  shutdown(): void {
+    Array.from(this.tasks.values()).forEach((task) => task.cancel());
+    this.tasks.clear();
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,10 @@
 import app from './index';
-import { getRuntimeConfig, loadEnv } from './env';
+import { getOperatorConfig, loadEnv } from './config/env';
 import { startWorker } from './worker';
 
 loadEnv();
 
-const runtimeConfig = getRuntimeConfig();
+const runtimeConfig = getOperatorConfig();
 const port = Number(process.env.PORT ?? runtimeConfig.port ?? 8080);
 const host = '0.0.0.0';
 

--- a/src/tests/basicAgentLoad.test.ts
+++ b/src/tests/basicAgentLoad.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import path from 'path';
+import { AgentLoader } from '../runtime/agentLoader';
+import { AgentContext } from '../runtime/agentContext';
+import { createLogger } from '../utils/logger';
+import { LocalEventBus } from '../runtime/eventBus';
+import { DevPsShaInfinity } from '../runtime/journal';
+import { getOperatorConfig, loadEnv } from '../config/env';
+
+let loader: AgentLoader;
+
+beforeAll(async () => {
+  loadEnv();
+  const config = getOperatorConfig();
+  const logger = createLogger('error');
+  const ctx: AgentContext = {
+    logger,
+    config,
+    eventBus: new LocalEventBus(logger),
+    journal: new DevPsShaInfinity(),
+    schedule: () => undefined,
+  };
+
+  loader = new AgentLoader(ctx);
+  const registryPath = path.join(process.cwd(), 'src/registry/agentsRegistry.yaml');
+  await loader.loadFromRegistry(registryPath);
+  await loader.initAll();
+});
+
+describe('AgentLoader', () => {
+  it('loads all agents from registry', () => {
+    const agents = loader.getAgents();
+    expect(agents.length).toBeGreaterThanOrEqual(10);
+  });
+});

--- a/src/tests/financeOrchestrator.test.ts
+++ b/src/tests/financeOrchestrator.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { FinanceOrchestrator } from '../orchestrators/financeOrchestrator';
+import { AgentContext } from '../runtime/agentContext';
+import { createLogger } from '../utils/logger';
+import { LocalEventBus } from '../runtime/eventBus';
+import { DevPsShaInfinity } from '../runtime/journal';
+import { getOperatorConfig, loadEnv } from '../config/env';
+
+function buildContext(): AgentContext {
+  loadEnv();
+  const config = getOperatorConfig();
+  const logger = createLogger('error');
+  return {
+    logger,
+    eventBus: new LocalEventBus(logger),
+    journal: new DevPsShaInfinity(),
+    config,
+    schedule: () => undefined,
+  };
+}
+
+describe('FinanceOrchestrator', () => {
+  it('runs orchestrations without throwing', async () => {
+    const orchestrator = new FinanceOrchestrator({ ctx: buildContext() });
+    await expect(orchestrator.runDailyDataSync()).resolves.toBeUndefined();
+    await expect(orchestrator.runWeeklyLiquidity()).resolves.toBeUndefined();
+    await expect(orchestrator.runMonthlyClose()).resolves.toBeUndefined();
+  });
+});

--- a/src/tests/scheduler.test.ts
+++ b/src/tests/scheduler.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { SystemScheduler } from '../runtime/systemScheduler';
+import { createLogger } from '../utils/logger';
+
+let scheduler: SystemScheduler;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  scheduler = new SystemScheduler(createLogger('error'));
+});
+
+afterEach(() => {
+  scheduler.shutdown();
+  vi.useRealTimers();
+});
+
+describe('SystemScheduler', () => {
+  it('executes scheduled functions', async () => {
+    const spy = vi.fn().mockResolvedValue(undefined);
+    scheduler.schedule('test', 1000, spy);
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -1,0 +1,13 @@
+import { Logger } from './logger';
+
+export function handleAsyncError(logger: Logger, context: string) {
+  return (err: unknown) => {
+    logger.error(`Error in ${context}:`, err);
+  };
+}
+
+export class DomainError extends Error {
+  constructor(message: string, public readonly domain?: string) {
+    super(message);
+  }
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,20 @@
+export interface Logger {
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  debug: (...args: unknown[]) => void;
+}
+
+export function createLogger(level: 'debug' | 'info' | 'warn' | 'error' = 'info'): Logger {
+  const levels: Record<string, number> = { debug: 10, info: 20, warn: 30, error: 40 };
+  const current = levels[level] ?? levels.info;
+
+  const shouldLog = (msgLevel: keyof typeof levels) => levels[msgLevel] >= current;
+
+  return {
+    info: (...args: unknown[]) => shouldLog('info') && console.info('[INFO]', ...args),
+    warn: (...args: unknown[]) => shouldLog('warn') && console.warn('[WARN]', ...args),
+    error: (...args: unknown[]) => shouldLog('error') && console.error('[ERROR]', ...args),
+    debug: (...args: unknown[]) => shouldLog('debug') && console.debug('[DEBUG]', ...args),
+  };
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,19 @@
+export const SECOND = 1000;
+export const MINUTE = 60 * SECOND;
+export const HOUR = 60 * MINUTE;
+export const DAY = 24 * HOUR;
+
+export function toMs(value: number, unit: 'seconds' | 'minutes' | 'hours' | 'days'): number {
+  switch (unit) {
+    case 'seconds':
+      return value * SECOND;
+    case 'minutes':
+      return value * MINUTE;
+    case 'hours':
+      return value * HOUR;
+    case 'days':
+      return value * DAY;
+    default:
+      return value;
+  }
+}


### PR DESCRIPTION
## Summary
- add typed operator configuration, runtime utilities, and scheduling primitives for agents
- scaffold finance, infra, compliance, ops, and research agents with registries and orchestrators plus internal API routes
- document architecture and agent lifecycle while adding vitest coverage for loader, orchestrator, and scheduler

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923737517a88329b097b36bc56cac26)