### PR TITLE
Fix lint issues in runtime scaffolding

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -46,6 +46,7 @@ export function createApp({ config, registry, queue, worker, eventBus, logger }:
   app.use("/internal", internalRouter);
 
   app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    void _next;
     logger.error("Unhandled error", err);
     const status = 500;
     return res.status(status).json({

--- a/src/runtime/agentRegistry.ts
+++ b/src/runtime/agentRegistry.ts
@@ -9,11 +9,11 @@ export interface AgentHandle<I = unknown, O = unknown> {
 export interface AgentMetadataWithState extends AgentMetadata, AgentState {}
 
 export class AgentRegistry {
-  private agents = new Map<PsShaInfinity, AgentHandle<any, any>>();
+  private agents = new Map<PsShaInfinity, AgentHandle<unknown, unknown>>();
 
   constructor(private logger?: Logger) {}
 
-  registerAgent(agent: CoreAgent<any, any>): void {
+  registerAgent<I, O>(agent: CoreAgent<I, O>): void {
     const existing = this.agents.get(agent.metadata.id);
     if (existing) {
       this.logger?.warn(`Agent ${agent.metadata.id} already registered, overwriting`);

--- a/src/runtime/jobQueue.ts
+++ b/src/runtime/jobQueue.ts
@@ -1,6 +1,6 @@
 import { Job, JobStatus, PsShaInfinity } from "blackroad-os-core";
 
-export interface QueuedJob<I = unknown, O = unknown> extends Job<I, O> {}
+export type QueuedJob<I = unknown, O = unknown> = Job<I, O>;
 
 export class InMemoryJobQueue {
   private queue: QueuedJob[] = [];

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -20,7 +20,6 @@ export function createLogger(level: LogLevel): Logger {
   const logAt = (msgLevel: LogLevel, args: unknown[]) => {
     if (levelWeights[msgLevel] < threshold) return;
     const prefix = `[${new Date().toISOString()}] [${msgLevel.toUpperCase()}]`;
-    // eslint-disable-next-line no-console
     console[msgLevel === "debug" ? "log" : msgLevel](prefix, ...args);
   };
 


### PR DESCRIPTION
## Summary
- mark unused Express error handler arg to satisfy linting
- tighten agent registry and queue typing to avoid `any` and empty interfaces
- remove unused ESLint override in logger utility

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692392a66b9c83298fc7e61275c02b73)