### PR TITLE
Add CADLAC language docs and examples

### DIFF
--- a/cadlac/README.md
+++ b/cadlac/README.md
@@ -1,0 +1,99 @@
+# CADLAC – Contractual Agreement Definition Language And Code
+
+CADLAC is an experimental, human-readable, machine-parseable contract language
+designed for use with the BlackRoad Operator and related systems.
+
+The goals:
+
+- Express **obligations, permissions, and prohibitions** in a structured way.
+- Be readable by non-engineers (lawyers, operators, biz).
+- Be parseable and enforceable by machines (operators, agents, smart contracts).
+- Bridge legal-style agreements and executable automation.
+
+## Core Concepts
+
+A CADLAC file is structured into semantic sections:
+
+- `contract` – top-level metadata and wrapper.
+- `scope` – term, jurisdiction, and global settings.
+- `parties` – named actors with roles.
+- `definitions` – reusable logical definitions and constants.
+- `obligations` – who MUST / MAY / MUST NOT do what.
+- `events` – named logical conditions that can be triggered.
+- `remedies` – what happens when events occur.
+
+### Minimal Example: NDA
+
+See `examples/hello_world_nda.cadlac`:
+
+```cadlac
+contract "Hello World NDA" version 1.0 {
+
+  parties {
+    Discloser role "Party A";
+    Recipient role "Party B";
+  }
+
+  scope {
+    term from "2025-01-01" to "2028-01-01";
+    jurisdiction "Delaware, USA";
+  }
+
+  definitions {
+    ConfidentialInformation =
+      any information marked "CONFIDENTIAL"
+      or shared in secure channels
+      except information that is (public OR independentlyDeveloped);
+  }
+
+  obligations {
+    Recipient MUST NOT disclose ConfidentialInformation
+      to anyThirdParty
+      during scope.term
+      AND for 2 years after scope.term.end;
+
+    Recipient MAY use ConfidentialInformation
+      onlyFor "evaluation of potential business relationship";
+  }
+
+  events {
+    event UnauthorisedDisclosure when
+      Recipient.discloses(ConfidentialInformation)
+      to anyThirdParty
+      without Discloser.priorWrittenConsent;
+  }
+
+  remedies {
+    on UnauthorisedDisclosure {
+      Recipient MUST pay liquidatedDamages of 100_000 USD;
+      Discloser MAY seek injunctiveRelief;
+      log "Breach: Unauthorised disclosure" severity HIGH;
+    }
+  }
+}
+```
+
+### Operator Integration (High Level)
+
+The BlackRoad Operator can eventually:
+
+1. **Parse CADLAC** contracts into an internal model:
+
+   * Parties, obligations, events, remedies.
+2. **Monitor events** from systems (logs, metrics, on-chain events).
+3. **Trigger remedies** (notifications, API calls, state changes).
+
+This repo currently focuses on:
+
+* Defining the language surface area (`spec/`).
+* Providing reference examples (`examples/`).
+
+Future work (candidate roadmap):
+
+* `parser/` – actual parser implementation (Python/TS/Rust).
+* `adapter/` – map `events` to Operator signals.
+* `enforcer/` – map `remedies` to Operator actions.
+
+See `spec/language_overview.md` for detailed semantics.
+
+```

--- a/cadlac/examples/hello_world_nda.cadlac
+++ b/cadlac/examples/hello_world_nda.cadlac
@@ -1,0 +1,44 @@
+contract "Hello World NDA" version 1.0 {
+
+  parties {
+    Discloser role "Party A";
+    Recipient role "Party B";
+  }
+
+  scope {
+    term from "2025-01-01" to "2028-01-01";
+    jurisdiction "Delaware, USA";
+  }
+
+  definitions {
+    ConfidentialInformation =
+      any information marked "CONFIDENTIAL"
+      or shared in secure channels
+      except information that is (public OR independentlyDeveloped);
+  }
+
+  obligations {
+    Recipient MUST NOT disclose ConfidentialInformation
+      to anyThirdParty
+      during scope.term
+      AND for 2 years after scope.term.end;
+
+    Recipient MAY use ConfidentialInformation
+      onlyFor "evaluation of potential business relationship";
+  }
+
+  events {
+    event UnauthorisedDisclosure when
+      Recipient.discloses(ConfidentialInformation)
+      to anyThirdParty
+      without Discloser.priorWrittenConsent;
+  }
+
+  remedies {
+    on UnauthorisedDisclosure {
+      Recipient MUST pay liquidatedDamages of 100_000 USD;
+      Discloser MAY seek injunctiveRelief;
+      log "Breach: Unauthorised disclosure" severity HIGH;
+    }
+  }
+}

--- a/cadlac/examples/saas_subscription.cadlac
+++ b/cadlac/examples/saas_subscription.cadlac
@@ -1,0 +1,53 @@
+contract "SaaS Subscription" version 0.1 {
+
+  scope {
+    term from "2025-03-01" to "2026-03-01";
+    autoRenew every 1 year unless Buyer.givesNotice 30 day;
+    jurisdiction "California, USA";
+  }
+
+  parties {
+    Provider role "SaaS Vendor";
+    Buyer    role "Customer";
+  }
+
+  definitions {
+    MonthlyFee = 99 USD;
+    DowntimeThreshold = 99.5 percent;
+  }
+
+  obligations {
+    Buyer MUST pay MonthlyFee
+      on first BusinessDay of eachMonth;
+
+    Provider MUST provideService
+      with uptime >= DowntimeThreshold
+      measured over rollingWindow 30 day;
+
+    Provider MUST notify Buyer
+      at least 7 day
+      before any priceIncrease;
+  }
+
+  events {
+    event ChronicDowntime when
+      uptime < DowntimeThreshold
+      for 3 consecutiveMonth;
+
+    event NonPayment when
+      Buyer.paymentOverdue > 15 day;
+  }
+
+  remedies {
+    on NonPayment {
+      Provider MAY suspendService;
+      Provider MUST notify Buyer "suspension due to non-payment";
+    }
+
+    on ChronicDowntime {
+      Buyer MAY terminateContract
+        with 0 dayNotice;
+      Provider MUST refund 2 * MonthlyFee;
+    }
+  }
+}

--- a/cadlac/spec/grammar_sketch.md
+++ b/cadlac/spec/grammar_sketch.md
@@ -1,0 +1,51 @@
+# CADLAC Grammar Sketch
+
+This is an informal, BNF-style sketch of the language.
+
+```text
+contract      ::= "contract" STRING "version" NUMBER "{" sections "}"
+sections      ::= { section }
+section       ::= scope | parties | definitions | obligations | events | remedies
+
+scope         ::= "scope" "{" scope_item* "}"
+scope_item    ::= "term" "from" DATE "to" DATE
+                | "jurisdiction" STRING
+                | IDENT "=" expression
+
+parties       ::= "parties" "{" party+ "}"
+party         ::= IDENT "role" STRING ["optional"]
+
+definitions   ::= "definitions" "{" definition+ "}"
+definition    ::= IDENT "=" expression
+
+obligations   ::= "obligations" "{" obligation+ "}"
+obligation    ::= subject modal action_clause
+
+events        ::= "events" "{" event+ "}"
+event         ::= "event" IDENT "when" condition
+
+remedies      ::= "remedies" "{" remedy+ "}"
+remedy        ::= "on" IDENT "{" action_clause+ "}"
+
+subject       ::= IDENT
+modal         ::= "MUST" | "MAY" | "MUST NOT"
+action_clause ::= expression
+
+expression    ::= (very lightly structured, mostly English-like DSL)
+condition     ::= expression (boolean-context)
+```
+
+This is not a full formal grammar yet, but good enough to start:
+
+* Writing a tokenizer / parser.
+* Mapping AST nodes into an internal Operator model.
+* Experimenting with contract-driven operations.
+
+Future refinements:
+
+* Types for amounts (`USD`, `ETH`, `percent`, `day`).
+* Time windows (`rollingWindow 30 day`).
+* Collections (`anyThirdParty`, `consecutiveMonth`).
+* Integration with event sources (`eth.balanceOf`, `uptime` metrics).
+
+```

--- a/cadlac/spec/language_overview.md
+++ b/cadlac/spec/language_overview.md
@@ -1,0 +1,123 @@
+# CADLAC Language Overview
+
+CADLAC (Contractual Agreement Definition Language And Code) is a DSL for
+expressing contracts as structured, semi-formal text.
+
+## Top-Level Structure
+
+Every file starts with a `contract` block:
+
+```cadlac
+contract "Name" version 1.0 {
+  scope { ... }
+  parties { ... }
+  definitions { ... }
+  obligations { ... }
+  events { ... }
+  remedies { ... }
+}
+```
+
+Sections:
+
+* `scope` – global metadata:
+
+  * `term from <DATE> to <DATE>`
+  * `jurisdiction <STRING>`
+  * other contract-wide settings.
+
+* `parties` – named actors:
+
+  ```cadlac
+  parties {
+    Seller  role "Provider";
+    Buyer   role "Customer";
+    Oracle  role "PriceFeed" optional;
+  }
+  ```
+
+* `definitions` – named expressions and constants:
+
+  ```cadlac
+  definitions {
+    BusinessDay =
+      any day where banksOpenIn("New York, USA")
+      AND NOT (isWeekend OR isPublicHoliday);
+
+    MonthlyFee = 99 USD;
+  }
+  ```
+
+* `obligations` – deontic statements (MUST / MAY / MUST NOT):
+
+  ```cadlac
+  obligations {
+    Seller MUST deliver "Digital Product"
+      within 3 BusinessDay of Buyer.paymentReceived;
+
+    Buyer MUST NOT shareAccessCredentials
+      with anyThirdParty;
+  }
+  ```
+
+* `events` – named logical conditions:
+
+  ```cadlac
+  events {
+    event LateDelivery when
+      Seller.deliveryDate > (Buyer.paymentDate + 3 BusinessDay);
+  }
+  ```
+
+* `remedies` – responses when events occur:
+
+  ```cadlac
+  remedies {
+    on LateDelivery {
+      Buyer MAY request discount 10 percent;
+      Seller MUST apply credit to nextInvoice;
+    }
+  }
+  ```
+
+## Keywords
+
+Core modal verbs:
+
+* `MUST` – hard obligation.
+* `MAY` – permission.
+* `MUST NOT` – prohibition.
+
+These map cleanly to an internal model:
+
+* `Obligation(subject, action)`
+* `Permission(subject, action)`
+* `Prohibition(subject, action)`
+
+## Intended Semantics
+
+The Operator can:
+
+1. Parse `obligations` into structured rules:
+
+   * who is responsible
+   * under what conditions
+   * what time constraints apply
+
+2. Parse `events` into trigger conditions that can be bound to:
+
+   * telemetry / metrics
+   * logs
+   * external system hooks
+   * on-chain events
+
+3. Parse `remedies` into actions:
+
+   * notifications
+   * workflow steps
+   * external API calls
+   * state transitions in the BlackRoad OS
+
+For a more formal sketch, see `grammar_sketch.md`.
+
+```


### PR DESCRIPTION
## Summary
- add CADLAC README describing the DSL and operator integration concepts
- include NDA and SaaS subscription sample contracts
- document the language overview and grammar sketch for future parser work

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923cebaac9c832992be6ba4d51f068b)