### PR TITLE
Add version endpoint and build metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ npm start
 All routes are prefixed with `/internal`:
 
 - `GET /internal/health` – runtime health including worker status and queue stats
+- `GET /internal/version` – build metadata (service, version, git SHA, uptime)
 - `GET /internal/agents` – list registered agents (supports `status` and `q` filters)
 - `GET /internal/agents/:id` – fetch a single agent
 - `POST /internal/jobs` – enqueue a job `{ type, agentId?, input? }`

--- a/docs/OPERATOR_RUNTIME_OVERVIEW.md
+++ b/docs/OPERATOR_RUNTIME_OVERVIEW.md
@@ -30,4 +30,4 @@ The Operator hosts agents and dispatches jobs using in-process primitives. It is
 3. Jobs can target the new agent by specifying `agentId` when enqueuing.
 
 ## Internal HTTP API
-The Express app mounted in `src/app.ts` exposes `/internal` routes for health, agents, jobs, and events. These endpoints are meant for internal services such as `blackroad-os-api`.
+The Express app mounted in `src/app.ts` exposes `/internal` routes for meta/build info, health, agents, jobs, and events. These endpoints are meant for internal services such as `blackroad-os-api`.

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,8 @@ import { createAgentsRouter } from "./routes/agents";
 import { createJobsRouter } from "./routes/jobs";
 import { createEventsRouter } from "./routes/events";
 import { createHealthRouter } from "./routes/health";
+import { BuildInfo } from "./utils/buildInfo";
+import { createMetaRouter } from "./routes/meta";
 
 export interface AppDependencies {
   config: OperatorConfig;
@@ -18,9 +20,10 @@ export interface AppDependencies {
   worker: Worker;
   eventBus: EventBus;
   logger: Logger;
+  buildInfo: BuildInfo;
 }
 
-export function createApp({ config, registry, queue, worker, eventBus, logger }: AppDependencies) {
+export function createApp({ config, registry, queue, worker, eventBus, logger, buildInfo }: AppDependencies) {
   const app = express();
 
   app.use(express.json());
@@ -34,6 +37,7 @@ export function createApp({ config, registry, queue, worker, eventBus, logger }:
   app.use(correlationIdMiddleware);
 
   const internalRouter = express.Router();
+  internalRouter.use(createMetaRouter({ buildInfo, config }));
   internalRouter.use(createHealthRouter({ worker, queue, config }));
   internalRouter.use(createAgentsRouter({ registry }));
   internalRouter.use(createJobsRouter({ queue, eventBus }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,12 @@ import { Worker } from "./runtime/worker";
 import { EventBus } from "./events/eventBus";
 import { InMemoryJournalStore, eventToJournalEntry } from "./integrations/journalStore";
 import { createLogger } from "./utils/logger";
+import { getBuildInfo } from "./utils/buildInfo";
 
 const config = getConfig();
 const logger = createLogger(config.logLevel);
+const startedAt = new Date().toISOString();
+const buildInfo = getBuildInfo(startedAt);
 const registry = createDefaultAgentRegistry(logger);
 const queue = new InMemoryJobQueue();
 const eventBus = new EventBus(config.eventBufferSize, logger);
@@ -25,7 +28,7 @@ const unsubscribeJournal = eventBus.subscribe((event) => {
 const worker = new Worker(registry, queue, eventBus, config, logger);
 worker.start();
 
-const app = createApp({ config, registry, queue, worker, eventBus, logger });
+const app = createApp({ config, registry, queue, worker, eventBus, logger, buildInfo });
 const server = http.createServer(app);
 
 server.listen(config.port, () => {

--- a/src/routes/meta.ts
+++ b/src/routes/meta.ts
@@ -1,0 +1,25 @@
+import { Router } from "express";
+import { OperatorConfig } from "../config";
+import { BuildInfo } from "../utils/buildInfo";
+
+interface MetaDeps {
+  buildInfo: BuildInfo;
+  config: OperatorConfig;
+}
+
+export function createMetaRouter({ buildInfo, config }: MetaDeps): Router {
+  const router = Router();
+
+  router.get("/version", (_req, res) => {
+    res.json({
+      ok: true,
+      data: {
+        ...buildInfo,
+        uptimeSeconds: Number(process.uptime().toFixed(3)),
+        logLevel: config.logLevel,
+      },
+    });
+  });
+
+  return router;
+}

--- a/src/utils/buildInfo.ts
+++ b/src/utils/buildInfo.ts
@@ -1,0 +1,37 @@
+import { execSync } from "child_process";
+import pkg from "../../package.json";
+
+export interface BuildInfo {
+  service: string;
+  version: string;
+  gitSha?: string;
+  buildTime?: string;
+  startedAt: string;
+  environment: string;
+  nodeVersion: string;
+}
+
+function resolveGitSha(): string | undefined {
+  if (process.env.GIT_SHA) return process.env.GIT_SHA;
+
+  try {
+    const output = execSync("git rev-parse --short HEAD", { stdio: ["ignore", "pipe", "ignore"] })
+      .toString()
+      .trim();
+    return output || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function getBuildInfo(startedAt: string): BuildInfo {
+  return {
+    service: pkg.name ?? "blackroad-os-operator",
+    version: pkg.version ?? "0.0.0",
+    gitSha: resolveGitSha(),
+    buildTime: process.env.BUILD_TIME,
+    startedAt,
+    environment: process.env.NODE_ENV ?? "development",
+    nodeVersion: process.version,
+  };
+}


### PR DESCRIPTION
## Summary
- add a build-info utility to surface service name, version, git SHA, build time, and runtime metadata
- expose an `/internal/version` endpoint that returns build info alongside uptime and log level
- document the new meta endpoint in the README and operator runtime overview

## Testing
- npm test *(fails: No test files found)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923e57890f08329ac0e6204a0979406)