### PR TITLE
Add script to push branches to all BlackRoad repos

### DIFF
--- a/docs/REPO_FANOUT_PUSH.md
+++ b/docs/REPO_FANOUT_PUSH.md
@@ -1,0 +1,34 @@
+# Repository fan-out push helper
+
+Use `scripts/git/push_to_all_repos.py` to broadcast the current branch of this
+repo to every BlackRoad repository listed in
+`integrations/devtools/github-organization.yaml`.
+
+## Usage
+
+```bash
+# Preview the remotes/commands that would run (default)
+./scripts/git/push_to_all_repos.py
+
+# Perform pushes over SSH to every repo in the BlackRoad-OS org
+./scripts/git/push_to_all_repos.py --execute
+
+# Target a specific branch name and include this repository in the fan-out
+./scripts/git/push_to_all_repos.py --execute --branch main --include-current
+```
+
+### Flags
+- `--config` — override the GitHub inventory path.
+- `--org` — override the organization (default: `BlackRoad-OS`).
+- `--protocol` — choose `ssh` (default) or `https` remotes.
+- `--remote-prefix` — prefix added to generated remotes (default: `fanout-`).
+- `--target` — one or more explicit repositories to push instead of the config list.
+- `--force` — use `--force-with-lease` when pushing.
+- `--execute` — required to perform actual pushes (otherwise dry-run).
+
+## Notes
+- The script creates remotes automatically when missing. Existing remotes are
+  reused.
+- Keep your git credentials configured for the chosen protocol before running
+  with `--execute`.
+- `--target` is handy for hotfix pushes when you only need a subset of repos.

--- a/scripts/git/push_to_all_repos.py
+++ b/scripts/git/push_to_all_repos.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Push the current branch to all known BlackRoad repositories.
+
+This script reads the GitHub inventory from
+`integrations/devtools/github-organization.yaml` and pushes the current branch
+(or a supplied branch name) to every listed repository. It is intentionally
+safe-by-default: the dry-run mode is enabled unless `--execute` is provided.
+
+Examples:
+    # Preview the remotes/commands without writing anything
+    ./scripts/git/push_to_all_repos.py
+
+    # Push the current branch to all repos under the BlackRoad-OS org
+    ./scripts/git/push_to_all_repos.py --execute
+
+    # Push a specific branch name and include the current repo in the fan-out
+    ./scripts/git/push_to_all_repos.py --execute --branch main --include-current
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = ROOT / "integrations" / "devtools" / "github-organization.yaml"
+
+
+def run(cmd: List[str]) -> None:
+    subprocess.run(cmd, check=True)
+
+
+def git_output(cmd: List[str]) -> str:
+    return subprocess.check_output(["git", *cmd], text=True).strip()
+
+
+def remote_exists(name: str) -> bool:
+    result = subprocess.run(["git", "remote", "get-url", name], capture_output=True)
+    return result.returncode == 0
+
+
+def add_remote(name: str, url: str, dry_run: bool) -> None:
+    if dry_run:
+        print(f"[dry-run] git remote add {name} {url}")
+        return
+
+    run(["git", "remote", "add", name, url])
+
+
+def push_remote(remote: str, source_branch: str, target_branch: str, force: bool, dry_run: bool) -> None:
+    push_args = ["git", "push", remote, f"{source_branch}:{target_branch}"]
+    if force:
+        push_args.append("--force-with-lease")
+
+    if dry_run:
+        print(f"[dry-run] {' '.join(push_args)}")
+        return
+
+    run(push_args)
+
+
+def load_repositories(path: Path) -> List[str]:
+    data = yaml.safe_load(path.read_text()) or {}
+    repos: Dict[str, object] = data.get("repositories", {})
+    return list(repos.keys())
+
+
+def build_remote_url(org: str, repo: str, protocol: str) -> str:
+    if protocol == "ssh":
+        return f"git@github.com:{org}/{repo}.git"
+    if protocol == "https":
+        return f"https://github.com/{org}/{repo}.git"
+    raise ValueError(f"Unsupported protocol: {protocol}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Push the current branch to all BlackRoad repos")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG, help="Path to GitHub org inventory YAML")
+    parser.add_argument("--org", default="BlackRoad-OS", help="GitHub organization name")
+    parser.add_argument("--branch", help="Branch name to push (defaults to current branch)")
+    parser.add_argument("--remote-prefix", default="fanout-", help="Prefix for generated remote names")
+    parser.add_argument("--protocol", choices=["ssh", "https"], default="ssh", help="Git remote protocol")
+    parser.add_argument("--include-current", action="store_true", help="Include this repo in the push fan-out")
+    parser.add_argument("--force", action="store_true", help="Use --force-with-lease when pushing")
+    parser.add_argument("--execute", action="store_true", help="Perform pushes (otherwise dry-run)")
+    parser.add_argument("--target", action="append", help="Explicit repository names to push (overrides config)")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    dry_run = not args.execute
+
+    config_path = args.config
+    if not config_path.exists():
+        raise SystemExit(f"Config file not found: {config_path}")
+
+    repositories: Iterable[str]
+    if args.target:
+        repositories = args.target
+    else:
+        repositories = load_repositories(config_path)
+
+    current_repo = ROOT.name
+    if not args.include_current:
+        repositories = [repo for repo in repositories if repo != current_repo]
+
+    current_branch = args.branch or git_output(["rev-parse", "--abbrev-ref", "HEAD"])
+
+    repo_list = list(repositories)
+    print(f"Preparing to push branch '{current_branch}' to {len(repo_list)} repositories...")
+
+    for repo in repo_list:
+        remote_name = f"{args.remote_prefix}{repo}"
+        remote_url = build_remote_url(args.org, repo, args.protocol)
+
+        if not remote_exists(remote_name):
+            add_remote(remote_name, remote_url, dry_run)
+
+        push_remote(remote_name, current_branch, args.branch or current_branch, args.force, dry_run)
+
+    if dry_run:
+        print("Dry-run complete. Re-run with --execute to perform pushes.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `scripts/git/push_to_all_repos.py` helper that reads the GitHub org inventory and fans out pushes with safe defaults
- document how to run the fan-out push workflow in `docs/REPO_FANOUT_PUSH.md`

## Testing
- ./scripts/git/push_to_all_repos.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f90efde348329bb4695044f55dc1b)