### PR TITLE
Add prism console section pages

### DIFF
--- a/prism-console/src/app/agents/page.tsx
+++ b/prism-console/src/app/agents/page.tsx
@@ -1,0 +1,140 @@
+/**
+ * BlackRoad OS - Prism Console Agents View
+ * Lists active agents, packs, and operational status
+ *
+ * @blackroad_name Agents
+ * @operator alexa.operator.v1
+ */
+
+const agents = [
+  {
+    name: 'Cece',
+    type: 'lucidia',
+    status: 'ready' as const,
+    uptime: '99.99%',
+    invocations: '1,247',
+    lastAction: 'policy:validate',
+  },
+  {
+    name: 'Beacon Router',
+    type: 'beacon',
+    status: 'busy' as const,
+    uptime: '99.9%',
+    invocations: '892',
+    lastAction: 'mesh:route',
+  },
+  {
+    name: 'Research Lab',
+    type: 'pack',
+    status: 'ready' as const,
+    uptime: '99.5%',
+    invocations: '456',
+    lastAction: 'agents:invoke',
+  },
+  {
+    name: 'Finance Pack',
+    type: 'pack',
+    status: 'ready' as const,
+    uptime: '99.8%',
+    invocations: '234',
+    lastAction: 'ledger:settle',
+  },
+  {
+    name: 'Legal Assistant',
+    type: 'custom',
+    status: 'paused' as const,
+    uptime: '98.4%',
+    invocations: '123',
+    lastAction: 'policy:draft',
+  },
+  {
+    name: 'DevOps Agent',
+    type: 'custom',
+    status: 'ready' as const,
+    uptime: '99.9%',
+    invocations: '567',
+    lastAction: 'operator:deploy',
+  },
+];
+
+const badges: Record<typeof agents[number]['status'], string> = {
+  ready: 'badge-success',
+  busy: 'badge-info',
+  paused: 'badge-warning',
+};
+
+export default function AgentsPage() {
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold text-white">Agents</h1>
+        <p className="text-gray-400">Operational status across Lucidia, Beacon, and Pack agents.</p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <SummaryCard title="Active" value="24" change="+3" />
+        <SummaryCard title="Average SLA" value="99.9%" change="+0.1%" />
+        <SummaryCard title="Current Invocations" value="1,856" change="+8%" />
+      </section>
+
+      <section className="card">
+        <div className="card-header">
+          <div>
+            <h2 className="card-title">Agent Roster</h2>
+            <p className="text-sm text-gray-500">Real-time posture pulled from Prism mesh.</p>
+          </div>
+          <div className="flex gap-2">
+            <span className="badge badge-success">ready</span>
+            <span className="badge badge-info">busy</span>
+            <span className="badge badge-warning">paused</span>
+          </div>
+        </div>
+
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Type</th>
+              <th>Status</th>
+              <th>Uptime</th>
+              <th>Invocations</th>
+              <th>Last Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {agents.map((agent) => (
+              <tr key={agent.name}>
+                <td className="font-medium text-white">{agent.name}</td>
+                <td className="text-gray-400">{agent.type}</td>
+                <td>
+                  <span className={`badge ${badges[agent.status]}`}>{agent.status}</span>
+                </td>
+                <td className="text-gray-400">{agent.uptime}</td>
+                <td className="text-gray-400">{agent.invocations}</td>
+                <td className="text-gray-400">{agent.lastAction}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}
+
+function SummaryCard({
+  title,
+  value,
+  change,
+}: {
+  title: string;
+  value: string;
+  change: string;
+}) {
+  return (
+    <div className="stat-card">
+      <div className="stat-label">{title}</div>
+      <div className="stat-value">{value}</div>
+      <div className="stat-change stat-change-up">↗ {change}</div>
+    </div>
+  );
+}

--- a/prism-console/src/app/collaboration/page.tsx
+++ b/prism-console/src/app/collaboration/page.tsx
@@ -1,0 +1,92 @@
+/**
+ * BlackRoad OS - Collaboration Hub
+ * Surfaces workrooms and synced operator notes from Prism
+ *
+ * @blackroad_name Collaboration
+ * @operator alexa.operator.v1
+ */
+
+const rooms = [
+  {
+    name: 'Apollo Launch',
+    members: 12,
+    status: 'active' as const,
+    summary: 'Coordinating launch readiness, approvals, and safety checks.',
+  },
+  {
+    name: 'IP Claims',
+    members: 6,
+    status: 'focus' as const,
+    summary: 'Legal + Lucidia research on filings and counter-claims.',
+  },
+  {
+    name: 'Incident Review',
+    members: 4,
+    status: 'active' as const,
+    summary: 'Post-incident analysis with ledger pulls and codex mapping.',
+  },
+];
+
+const statusBadge: Record<typeof rooms[number]['status'], string> = {
+  active: 'badge-success',
+  focus: 'badge-warning',
+};
+
+export default function CollaborationPage() {
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold text-white">Collaboration</h1>
+        <p className="text-gray-400">Prism-synced workrooms and operator handoffs.</p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <StatCard title="Rooms" value="9" caption="Active" />
+        <StatCard title="Participants" value="34" caption="Across ops + legal" />
+        <StatCard title="Handoffs (24h)" value="57" caption="Prism → Operator" />
+      </section>
+
+      <section className="card">
+        <div className="card-header">
+          <h2 className="card-title">Active Rooms</h2>
+          <span className="text-xs text-gray-500">Synced every 30s</span>
+        </div>
+
+        <div className="space-y-4">
+          {rooms.map((room) => (
+            <div key={room.name} className="rounded-lg border border-gray-800/70 bg-gray-900/40 p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="font-medium text-white">{room.name}</p>
+                  <p className="text-sm text-gray-500">{room.summary}</p>
+                </div>
+                <div className="flex items-center gap-2 text-sm text-gray-400">
+                  <span className={`badge ${statusBadge[room.status]}`}>{room.status}</span>
+                  <span className="badge badge-info">{room.members} members</span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function StatCard({
+  title,
+  value,
+  caption,
+}: {
+  title: string;
+  value: string;
+  caption: string;
+}) {
+  return (
+    <div className="stat-card">
+      <div className="stat-label">{title}</div>
+      <div className="stat-value">{value}</div>
+      <div className="text-xs text-gray-500">{caption}</div>
+    </div>
+  );
+}

--- a/prism-console/src/app/governance/page.tsx
+++ b/prism-console/src/app/governance/page.tsx
@@ -1,0 +1,161 @@
+/**
+ * BlackRoad OS - Governance Console
+ * Policy compliance posture and decision logs
+ *
+ * @blackroad_name Governance
+ * @operator alexa.operator.v1
+ */
+
+const controls = [
+  {
+    name: 'Zero-Knowledge Access',
+    coverage: 'Enabled for all user auth',
+    status: 'healthy' as const,
+  },
+  {
+    name: 'Ledger Replication',
+    coverage: 'Archive + primary regions',
+    status: 'healthy' as const,
+  },
+  {
+    name: 'AI Safety Harness',
+    coverage: 'All Lucidia and Pack agents',
+    status: 'attention' as const,
+  },
+  {
+    name: 'Supply Chain Attestation',
+    coverage: 'Operator + Gateway builds',
+    status: 'healthy' as const,
+  },
+];
+
+const decisions = [
+  {
+    action: 'agents:invoke',
+    entity: 'agent-cece',
+    policy: 'Explainability Doctrine',
+    outcome: 'allow' as const,
+    time: '2 min ago',
+  },
+  {
+    action: 'operator:deploy',
+    entity: 'service-api',
+    policy: 'Side Channel Budget',
+    outcome: 'allow' as const,
+    time: '5 min ago',
+  },
+  {
+    action: 'mesh:connect',
+    entity: 'node-pi-42',
+    policy: 'Resilience Code',
+    outcome: 'escalate' as const,
+    time: '8 min ago',
+  },
+  {
+    action: 'data:access',
+    entity: 'user-123',
+    policy: 'Identity Guard',
+    outcome: 'deny' as const,
+    time: '12 min ago',
+  },
+];
+
+const outcomeBadge: Record<typeof decisions[number]['outcome'], string> = {
+  allow: 'badge-success',
+  deny: 'badge-error',
+  escalate: 'badge-warning',
+};
+
+export default function GovernancePage() {
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold text-white">Governance</h1>
+        <p className="text-gray-400">Codex-aligned policies, safety controls, and recent decisions.</p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <SummaryCard title="Policy Coverage" value="98%" description="Controls mapped to services" />
+        <SummaryCard title="Open Incidents" value="2" description="Both under review" />
+        <SummaryCard title="Evaluations (24h)" value="1.2M" description="Policy engine throughput" />
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <div className="card">
+          <div className="card-header">
+            <div>
+              <h2 className="card-title">Safety Controls</h2>
+              <p className="text-sm text-gray-500">Enforced in Prism runtime.</p>
+            </div>
+          </div>
+          <div className="space-y-4">
+            {controls.map((control) => (
+              <div key={control.name} className="rounded-lg border border-gray-800/70 bg-gray-900/40 p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium text-white">{control.name}</p>
+                    <p className="text-sm text-gray-500">{control.coverage}</p>
+                  </div>
+                  <span
+                    className={`badge ${control.status === 'healthy' ? 'badge-success' : 'badge-warning'}`}
+                  >
+                    {control.status}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="card-header">
+            <h2 className="card-title">Recent Decisions</h2>
+            <span className="text-xs text-gray-500">Synced from Prism ledger</span>
+          </div>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Action</th>
+                <th>Entity</th>
+                <th>Policy</th>
+                <th>Outcome</th>
+                <th>Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {decisions.map((decision) => (
+                <tr key={`${decision.action}-${decision.time}`}>
+                  <td>{decision.action}</td>
+                  <td className="text-gray-400">{decision.entity}</td>
+                  <td className="text-gray-400">{decision.policy}</td>
+                  <td>
+                    <span className={`badge ${outcomeBadge[decision.outcome]}`}>{decision.outcome}</span>
+                  </td>
+                  <td className="text-gray-400">{decision.time}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function SummaryCard({
+  title,
+  value,
+  description,
+}: {
+  title: string;
+  value: string;
+  description: string;
+}) {
+  return (
+    <div className="stat-card">
+      <div className="stat-label">{title}</div>
+      <div className="stat-value">{value}</div>
+      <div className="text-xs text-gray-500">{description}</div>
+    </div>
+  );
+}

--- a/prism-console/src/app/intents/page.tsx
+++ b/prism-console/src/app/intents/page.tsx
@@ -1,0 +1,96 @@
+/**
+ * BlackRoad OS - Intent Router
+ * View queued intents and routing paths from Prism
+ *
+ * @blackroad_name Intents
+ * @operator alexa.operator.v1
+ */
+
+const intents = [
+  {
+    id: 'intent-982',
+    description: 'File IP claim for user-123',
+    route: 'legal → lucidia → ledger',
+    status: 'queued' as const,
+    priority: 'high',
+  },
+  {
+    id: 'intent-983',
+    description: 'Deploy updated gateway config',
+    route: 'devops → operator',
+    status: 'in-flight' as const,
+    priority: 'medium',
+  },
+  {
+    id: 'intent-984',
+    description: 'Research competitor filings',
+    route: 'research-lab → archive',
+    status: 'in-flight' as const,
+    priority: 'low',
+  },
+];
+
+const statusBadge: Record<typeof intents[number]['status'], string> = {
+  queued: 'badge-warning',
+  'in-flight': 'badge-info',
+};
+
+export default function IntentsPage() {
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold text-white">Intents</h1>
+        <p className="text-gray-400">Queued and executing intents routed through Prism.</p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <StatCard label="Queued" value="12" trend="+2" />
+        <StatCard label="In Flight" value="8" trend="+1" />
+        <StatCard label="Completed (24h)" value="214" trend="+12%" />
+      </section>
+
+      <section className="card">
+        <div className="card-header">
+          <h2 className="card-title">Active Intents</h2>
+          <span className="text-xs text-gray-500">Prism router</span>
+        </div>
+
+        <div className="space-y-4">
+          {intents.map((intent) => (
+            <div key={intent.id} className="rounded-lg border border-gray-800/70 bg-gray-900/40 p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="font-medium text-white">{intent.description}</p>
+                  <p className="text-sm text-gray-500">{intent.route}</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className={`badge ${statusBadge[intent.status]}`}>{intent.status}</span>
+                  <span className="badge badge-success">{intent.priority} priority</span>
+                </div>
+              </div>
+              <p className="mt-2 font-mono text-xs text-gray-500">{intent.id}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  trend,
+}: {
+  label: string;
+  value: string;
+  trend: string;
+}) {
+  return (
+    <div className="stat-card">
+      <div className="stat-label">{label}</div>
+      <div className="stat-value">{value}</div>
+      <div className="stat-change stat-change-up">↗ {trend}</div>
+    </div>
+  );
+}

--- a/prism-console/src/app/ledger/page.tsx
+++ b/prism-console/src/app/ledger/page.tsx
@@ -1,0 +1,98 @@
+/**
+ * BlackRoad OS - Ledger View
+ * Event stream surfaced from Prism console
+ *
+ * @blackroad_name Ledger
+ * @operator alexa.operator.v1
+ */
+
+const events = [
+  {
+    id: 'evt_abc123',
+    action: 'agents:invoke',
+    entity: 'agent-cece',
+    decision: 'allow' as const,
+    time: '2 min ago',
+  },
+  {
+    id: 'evt_def456',
+    action: 'mesh:connect',
+    entity: 'node-pi-42',
+    decision: 'allow' as const,
+    time: '5 min ago',
+  },
+  {
+    id: 'evt_ghi789',
+    action: 'operator:deploy',
+    entity: 'service-api',
+    decision: 'allow' as const,
+    time: '12 min ago',
+  },
+  {
+    id: 'evt_jkl012',
+    action: 'agents:invoke',
+    entity: 'agent-beacon',
+    decision: 'deny' as const,
+    time: '15 min ago',
+  },
+  {
+    id: 'evt_mno345',
+    action: 'data:access',
+    entity: 'user-123',
+    decision: 'allow' as const,
+    time: '20 min ago',
+  },
+];
+
+const decisionBadge: Record<typeof events[number]['decision'], string> = {
+  allow: 'badge-success',
+  deny: 'badge-error',
+};
+
+export default function LedgerPage() {
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold text-white">Ledger</h1>
+        <p className="text-gray-400">Signed decisions streamed from Prism for auditing.</p>
+      </header>
+
+      <section className="card">
+        <div className="card-header">
+          <div>
+            <h2 className="card-title">Recent Ledger Events</h2>
+            <p className="text-sm text-gray-500">Rolling 24h window</p>
+          </div>
+          <a href="/governance" className="text-sm text-[var(--br-orange)] hover:underline">
+            View policy mapping
+          </a>
+        </div>
+
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Event ID</th>
+              <th>Action</th>
+              <th>Entity</th>
+              <th>Decision</th>
+              <th>Time</th>
+            </tr>
+          </thead>
+          <tbody>
+            {events.map((event) => (
+              <tr key={event.id}>
+                <td className="font-mono text-xs text-gray-400">{event.id}</td>
+                <td>{event.action}</td>
+                <td className="text-gray-400">{event.entity}</td>
+                <td>
+                  <span className={`badge ${decisionBadge[event.decision]}`}>{event.decision}</span>
+                </td>
+                <td className="text-gray-400">{event.time}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}

--- a/prism-console/src/app/settings/page.tsx
+++ b/prism-console/src/app/settings/page.tsx
@@ -1,0 +1,53 @@
+/**
+ * BlackRoad OS - Prism Settings
+ * Environment + transport settings surfaced from Prism
+ *
+ * @blackroad_name Settings
+ * @operator alexa.operator.v1
+ */
+
+const settings = [
+  {
+    name: 'Environment',
+    value: 'production',
+    detail: 'Railway primary + archive',
+  },
+  {
+    name: 'Ledger Replication',
+    value: 'enabled',
+    detail: 'Archive + 2 regions',
+  },
+  {
+    name: 'Event Bus',
+    value: 'prism-console',
+    detail: 'Kafka → EventBridge mirror',
+  },
+  {
+    name: 'Access Control',
+    value: 'codex + ledger',
+    detail: 'Policy + signed attestations',
+  },
+];
+
+export default function SettingsPage() {
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold text-white">Settings</h1>
+        <p className="text-gray-400">Shared configuration mirrored from Prism runtime.</p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        {settings.map((setting) => (
+          <div key={setting.name} className="card">
+            <div className="card-header">
+              <h2 className="card-title">{setting.name}</h2>
+              <span className="badge badge-success">{setting.value}</span>
+            </div>
+            <p className="text-sm text-gray-500">{setting.detail}</p>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add dedicated Prism Console pages for agents, governance, ledger, intents, collaboration, and settings
- populate each page with representative Prism runtime data and status badges

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693353e852c48329b657a6f32ae254c8)